### PR TITLE
Add admin & email translation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 #### Translation
-Currently only the account creation form can be translated. Strings are defined in `lang/form/<country-code>.json` (country code as in `en-us`, `fr-fr`, e.g). You can see the existing ones [here](https://github.com/hrfee/jfa-go/tree/main/lang/form).
+Currently the admin page, account creation form and emails can be translated. Strings are defined in `lang/<admin/form/email>/<country-code>.json` (country code as in `en-us`, `fr-fr`, e.g). You can see the existing ones [here](https://github.com/hrfee/jfa-go/tree/main/lang).
 Make sure to define `name` in the `meta` section, and you can optionally add an `author` value there as well. If you can, make a pull request with your new file. If not, email me or create an issue.
 
 #### Code

--- a/api.go
+++ b/api.go
@@ -1237,9 +1237,16 @@ func (app *appContext) Logout(gc *gin.Context) {
 // @Router /lang [get]
 // @tags Other
 func (app *appContext) GetLanguages(gc *gin.Context) {
+	page := gc.Param("page")
 	resp := langDTO{}
-	for key, lang := range app.storage.lang.Form {
-		resp[key] = lang["meta"].(map[string]interface{})["name"].(string)
+	if page == "form" {
+		for key, lang := range app.storage.lang.Form {
+			resp[key] = lang["meta"].(map[string]interface{})["name"].(string)
+		}
+	} else if page == "admin" {
+		for key, lang := range app.storage.lang.Admin {
+			resp[key] = lang["meta"].(map[string]interface{})["name"].(string)
+		}
 	}
 	if len(resp) == 0 {
 		respond(500, "Couldn't get languages", gc)

--- a/api.go
+++ b/api.go
@@ -455,7 +455,7 @@ func (app *appContext) DeleteUser(gc *gin.Context) {
 						app.err.Printf("%s: Failed to send to %s", userID, address)
 						app.debug.Printf("%s: Error: %s", userID, err)
 					} else {
-						app.info.Printf("%s: Sent invite email to %s", userID, address)
+						app.info.Printf("%s: Sent deletion email to %s", userID, address)
 					}
 				}(userID, req.Reason, addr.(string))
 			}
@@ -1176,7 +1176,7 @@ func (app *appContext) ModifyConfig(gc *gin.Context) {
 							break
 						}
 					}
-				} else {
+				} else if value.(string) != app.config.Section(section).Key(setting).MustString("") {
 					tempConfig.Section(section).Key(setting).SetValue(value.(string))
 				}
 			}

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ func (app *appContext) loadConfig() error {
 			key.SetValue(key.MustString(filepath.Join(app.dataPath, (key.Name() + ".json"))))
 		}
 	}
-	for _, key := range []string{"user_configuration", "user_displayprefs", "user_profiles", "ombi_template"} {
+	for _, key := range []string{"user_configuration", "user_displayprefs", "user_profiles", "ombi_template", "invites", "emails", "user_template"} {
 		// if app.config.Section("files").Key(key).MustString("") == "" {
 		// 	key.SetValue(filepath.Join(app.data_path, (key.Name() + ".json")))
 		// }
@@ -80,8 +80,6 @@ func (app *appContext) loadConfig() error {
 	app.config.Section("jellyfin").Key("device").SetValue("jfa-go")
 	app.config.Section("jellyfin").Key("device_id").SetValue(fmt.Sprintf("jfa-go-%s-%s", VERSION, COMMIT))
 
-	app.email = NewEmailer(app)
-
 	substituteStrings = app.config.Section("jellyfin").Key("substitute_jellyfin_strings").MustString("")
 
 	oldFormLang := app.config.Section("ui").Key("language").MustString("")
@@ -93,6 +91,9 @@ func (app *appContext) loadConfig() error {
 		app.storage.lang.chosenFormLang = newFormLang
 	}
 	app.storage.lang.chosenAdminLang = app.config.Section("ui").Key("language-admin").MustString("en-us")
+	app.storage.lang.chosenEmailLang = app.config.Section("email").Key("language").MustString("en-us")
+
+	app.email = NewEmailer(app)
 
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -85,6 +85,7 @@ func (app *appContext) loadConfig() error {
 	substituteStrings = app.config.Section("jellyfin").Key("substitute_jellyfin_strings").MustString("")
 
 	app.storage.lang.chosenFormLang = app.config.Section("ui").Key("language").MustString("en-us")
+	app.storage.lang.chosenFormLang = app.config.Section("ui").Key("language").MustString("en-us")
 
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -84,8 +84,15 @@ func (app *appContext) loadConfig() error {
 
 	substituteStrings = app.config.Section("jellyfin").Key("substitute_jellyfin_strings").MustString("")
 
-	app.storage.lang.chosenFormLang = app.config.Section("ui").Key("language").MustString("en-us")
-	app.storage.lang.chosenFormLang = app.config.Section("ui").Key("language").MustString("en-us")
+	oldFormLang := app.config.Section("ui").Key("language").MustString("")
+	if oldFormLang != "" {
+		app.storage.lang.chosenFormLang = oldFormLang
+	}
+	newFormLang := app.config.Section("ui").Key("language-form").MustString("")
+	if newFormLang != "" {
+		app.storage.lang.chosenFormLang = newFormLang
+	}
+	app.storage.lang.chosenAdminLang = app.config.Section("ui").Key("language-admin").MustString("en-us")
 
 	return nil
 }

--- a/config/config-base.json
+++ b/config/config-base.json
@@ -277,6 +277,18 @@
                 "description": "General email settings. Ignore if not using email features."
             },
             "settings": {
+                "language": {
+                    "name": "Email Language",
+                    "required": false,
+                    "requires_restart": false,
+                    "depends_true": "method",
+                    "type": "select",
+                    "options": [
+                        "en-us"
+                    ],
+                    "value": "en-us",
+                    "description": "Default email language. Submit a PR on github if you'd like to translate."
+                },
                 "no_username": {
                     "name": "Use email addresses as username",
                     "required": false,

--- a/config/config-base.json
+++ b/config/config-base.json
@@ -84,7 +84,7 @@
                 "description": "Settings related to the UI and program functionality."
             },
             "settings": {
-                "language": {
+                "language-form": {
                     "name": "Default Form Language",
                     "required": false,
                     "requires_restart": true,
@@ -93,7 +93,18 @@
                         "en-us"
                     ],
                     "value": "en-US",
-                    "description": "Default UI Language. Currently only implemented for account creation form. Submit a PR on github if you'd like to translate."
+                    "description": "Default Account Form Language. Submit a PR on github if you'd like to translate."
+                },
+                "language-admin": {
+                    "name": "Default Admin Language",
+                    "required": false,
+                    "requires_restart": true,
+                    "type": "select",
+                    "options": [
+                        "en-us"
+                    ],
+                    "value": "en-US",
+                    "description": "Default Admin page Language. Settings has not been translated. Submit a PR on github if you'd like to translate."
                 },
                 "theme": {
                     "name": "Default Look",

--- a/html/admin.html
+++ b/html/admin.html
@@ -167,6 +167,16 @@
             </form>
         </div>
         <div id="notification-box"></div>
+        <span class="dropdown" tabindex="0" id="lang-dropdown">
+            <span class="button ~urge dropdown-button">
+                <i class="ri-global-line"></i>
+                <span class="ml-1 chev"></span>
+            </span>
+            <div class="dropdown-display">
+                <div class="card ~neutral !low" id="lang-list">
+                </div>
+            </div>
+        </span>
         <div class="page-container">
             <div class="mb-1">
                 <header class="flex flex-wrap items-center justify-between">

--- a/html/admin.html
+++ b/html/admin.html
@@ -264,6 +264,7 @@
                                 <tr>
                                     <th><input type="checkbox" value="" id="accounts-select-all"></th>
                                     <th>{{ .strings.username }}</th>
+                                    <th>{{ .strings.language }}</th>
                                     <th>{{ .strings.emailAddress }}</th>
                                     <th>{{ .strings.lastActiveTime }}</th>
                                 </tr>

--- a/html/admin.html
+++ b/html/admin.html
@@ -99,7 +99,7 @@
                 <span class="heading">{{ .strings.settingsRestartRequired }} <span class="modal-close">&times;</span></span>
                 <p class="content pb-1">{{ .strings.settingsRestartRequiredDescription }}</p>
                 <div class="fr">
-                    <span class="button ~info !normal" id="settings-apply-no-restart">{{ .strings.settingsApplyRestartLater }}</span>
+                    <span class="button ~info !normal mb-half" id="settings-apply-no-restart">{{ .strings.settingsApplyRestartLater }}</span>
                     <span class="button ~critical !normal" id="settings-apply-restart">{{ .strings.settingsApplyRestartNow }}</span>
                 </div>
             </div>
@@ -264,7 +264,6 @@
                                 <tr>
                                     <th><input type="checkbox" value="" id="accounts-select-all"></th>
                                     <th>{{ .strings.username }}</th>
-                                    <th>{{ .strings.language }}</th>
                                     <th>{{ .strings.emailAddress }}</th>
                                     <th>{{ .strings.lastActiveTime }}</th>
                                 </tr>

--- a/html/admin.html
+++ b/html/admin.html
@@ -9,6 +9,7 @@
             window.emailEnabled = {{ .email_enabled }};
             window.ombiEnabled = {{ .ombiEnabled }};
             window.usernamesEnabled = {{ .username }};
+            window.langFile = JSON.parse({{ .language }});
         </script>
         {{ template "header.html" . }}
         <title>Admin - jfa-go</title>
@@ -264,7 +265,7 @@
             </div>
             <div id="tab-settings" class="unfocused">
                 <div class="card ~neutral !low settings overflow">
-                    <span class="heading">{{ .string.settings }}</span>
+                    <span class="heading">{{ .strings.settings }}</span>
                     <div class="fr">
                         <span class="button ~neutral !normal unfocused" id="settings-save">{{ .strings.settingsSave }}</span>
                     </div>

--- a/html/admin.html
+++ b/html/admin.html
@@ -8,7 +8,7 @@
             window.notificationsEnabled = {{ .notifications }};
             window.emailEnabled = {{ .email_enabled }};
             window.ombiEnabled = {{ .ombiEnabled }};
-            window.usernamesEnabled = {{ .username }};
+            window.usernameEnabled = {{ .username }};
             window.langFile = JSON.parse({{ .language }});
         </script>
         {{ template "header.html" . }}

--- a/html/admin.html
+++ b/html/admin.html
@@ -16,164 +16,152 @@
     <body class="max-w-full overflow-x-hidden section">
         <div id="modal-login" class="modal">
             <form class="modal-content card" id="form-login" href="">
-                <span class="heading">Login</span>
-                <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="username" id="login-user">
-                <input type="password" class="field input ~neutral !high mb-1" placeholder="password" id="login-password">
+                <span class="heading">{{ .strings.login }}</span>
+                <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="{{ .strings.username }}" id="login-user">
+                <input type="password" class="field input ~neutral !high mb-1" placeholder="{{ .strings.password }}" id="login-password">
                 <label>
                     <input type="submit" class="unfocused">
-                    <span class="button ~urge !normal full-width center supra submit">Login</span>
+                    <span class="button ~urge !normal full-width center supra submit">{{ .strings.login }}</span>
                 </label>
             </form>
         </div>
         <div id="modal-add-user" class="modal">
             <form class="modal-content card" id="form-add-user" href="">
-                <span class="heading">New User <span class="modal-close">&times;</span></span>
-                <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="username" id="add-user-user">
-                <input type="email" class="field input ~neutral !high mt-half mb-1" placeholder="email address">
-                <input type="password" class="field input ~neutral !high mb-1" placeholder="password" id="add-user-password">
+                <span class="heading">{{ .strings.newUser }} <span class="modal-close">&times;</span></span>
+                <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="{{ .strings.username }}" id="add-user-user">
+                <input type="email" class="field input ~neutral !high mt-half mb-1" placeholder="{{ .strings.emailAddress }}">
+                <input type="password" class="field input ~neutral !high mb-1" placeholder="{{ .strings.password }}" id="add-user-password">
                 <label>
                     <input type="submit" class="unfocused">
-                    <span class="button ~urge !normal full-width center supra submit">Create</span>
+                    <span class="button ~urge !normal full-width center supra submit">{{ .strings.create }}</span>
                 </label>
             </form>
         </div>
         <div id="modal-about" class="modal">
             <div class="modal-content content card">
-                <span class="heading">About <span class="modal-close">&times;</span></span>
+                <span class="heading">{{ .strings.aboutProgram }} <span class="modal-close">&times;</span></span>
                 <img src="/banner.svg" class="mt-1" alt="jfa-go banner">
                 <p><i class="icon ri-github-fill"></i><a href="https://github.com/hrfee/jfa-go">jfa-go</a></p>
-                <p>Version <span class="code monospace">{{ .version }}</span></p>
-                <p>Commit <span class="code monospace">{{ .commit }}</span></p>
+                <p>{{ .strings.version }} <span class="code monospace">{{ .version }}</span></p>
+                <p>{{ .strings.commitNoun }} <span class="code monospace">{{ .commit }}</span></p>
                 <p><a href="https://github.com/hrfee/jfa-go/blob/main/LICENSE">Available under the MIT License.</a></p>
             </div>
         </div>
         <div id="modal-modify-user" class="modal">
             <form class="modal-content card" id="form-modify-user" href="">
-                <span class="heading">Modify Settings for <span id="header-modify-user"></span> <span class="modal-close">&times;</span></span>
-                <p class="content">Apply settings from an existing profile, or source them directly from a user.</p>
+                <span class="heading"><span id="header-modify-user"></span> <span class="modal-close">&times;</span></span>
+                <p class="content">{{ .strings.modifySettingsDescription }}</p>
                 <div class="flex-row mb-1">
                     <label class="flex-row-group mr-1">
                         <input type="radio" name="modify-user-source" class="unfocused" id="radio-use-profile" checked>
-                        <span class="button ~neutral !high supra full-width center">Profile</span>
+                        <span class="button ~neutral !high supra full-width center">{{ .strings.profile }}</span>
                     </label>
                     <label class="flex-row-group ml-1">
                         <input type="radio" name="modify-user-source" class="unfocused" id="radio-use-user">
-                        <span class="button ~neutral !normal supra full-width center">User</span>
+                        <span class="button ~neutral !normal supra full-width center">{{ .strings.user }}</span>
                     </label>
                 </div>
                 <div class="select ~neutral !normal mb-1">
-                    <select id="modify-user-profiles">
-                        <option>Friends</option>
-                        <option>Family</option>
-                        <option>Default</option>
-                    </select>
+                    <select id="modify-user-profiles"></select>
                 </div>
                 <div class="select ~neutral !normal mb-1 unfocused">
-                    <select id="modify-user-users">
-                        <option>Person</option>
-                        <option>Other person</option>
-                    </select>
+                    <select id="modify-user-users"></select>
                 </div>
                 <label class="switch mb-1">
                     <input type="checkbox" id="modify-user-homescreen" checked>
-                    <span>Apply homescreen layout</span>
+                    <span>{{ .strings.applyHomescreenLayout }}</span>
                 </label>
                 <label>
                     <input type="submit" class="unfocused">
-                    <span class="button ~urge !normal full-width center supra submit">Apply</span>
+                    <span class="button ~urge !normal full-width center supra submit">{{ .strings.apply }}</span>
                 </label>
             </form>
         </div>
         <div id="modal-delete-user" class="modal">
             <form class="modal-content card" id="form-delete-user" href="">
-                <span class="heading">Delete <span id="header-delete-user"></span> <span class="modal-close">&times;</span></span>
+                <span class="heading"><span id="header-delete-user"></span> <span class="modal-close">&times;</span></span>
                 <div class="content mt-half">
                     <label class="switch mb-1">
                         <input type="checkbox" id="delete-user-notify" checked>
-                        <span>Send notification email</span>
+                        <span>{{ .strings.sendDeleteNotificationEmail }}</span>
                     </label>
-                    <textarea id="textarea-delete-user" class="textarea full-width ~neutral !normal mb-1" placeholder="Your account has been deleted."></textarea>
+                    <textarea id="textarea-delete-user" class="textarea full-width ~neutral !normal mb-1" placeholder="{{ .strings.sendDeleteNotificationExample }}"></textarea>
                     <label>
                         <input type="submit" class="unfocused">
-                        <span class="button ~critical !normal full-width center supra submit">Delete</span>
+                        <span class="button ~critical !normal full-width center supra submit">{{ .strings.delete }}</span>
                     </label>
                 </div>
             </form>
         </div>
         <div id="modal-restart" class="modal">
             <div class="modal-content card ~critical !low">
-                <span class="heading">Restart needed <span class="modal-close">&times;</span></span>
-                <p class="content pb-1">A restart is needed to apply some settings you changed. Do it now or later?</p>
+                <span class="heading">{{ .strings.settingsRestartRequired }} <span class="modal-close">&times;</span></span>
+                <p class="content pb-1">{{ .strings.settingsRestartRequiredDescription }}</p>
                 <div class="fr">
-                    <span class="button ~info !normal" id="settings-apply-no-restart">Apply, restart later</span>
-                    <span class="button ~critical !normal" id="settings-apply-restart">Apply &amp; restart</span>
+                    <span class="button ~info !normal" id="settings-apply-no-restart">{{ .strings.settingsApplyRestartLater }}</span>
+                    <span class="button ~critical !normal" id="settings-apply-restart">{{ .strings.settingsApplyRestartNow }}</span>
                 </div>
             </div>
         </div>
         <div id="modal-refresh" class="modal">
             <div class="modal-content card ~neutral !normal">
-                <span class="heading">Settings applied.</span>
-                <p class="content">Refresh the page in a few seconds.</p>
+                <span class="heading">{{ .strings.settingsApplied }}</span>
+                <p class="content">{{ .strings.settingsRefreshPage }}</p>
             </div>
         </div>
         <div id="modal-ombi-defaults" class="modal">
             <form class="modal-content card" id="form-ombi-defaults" href="">
-                <span class="heading">Ombi user defaults <span class="modal-close">&times;</span></span>
-                <p class="content">Create an Ombi user and configure it, then select it here. It's settings/permissions will be stored and applied to new ombi users created by jfa-go.</p>
+                <span class="heading">{{ .strings.ombiUserDefaults }} <span class="modal-close">&times;</span></span>
+                <p class="content">{{ .strings.ombiUserDefaultsDescription }}</p>
                 <div class="select ~neutral !normal mb-1">
-                    <select>
-                        <option>Person</option>
-                        <option>Other person</option>
-                    </select>
+                    <select></select>
                 </div>
                 <label>
                     <input type="submit" class="unfocused">
-                    <span class="button ~urge !normal full-width center supra submit">Submit</span>
+                    <span class="button ~urge !normal full-width center supra submit">{{ .strings.submit }}</span>
                 </label>
             </form>
         </div>
         <div id="modal-user-profiles" class="modal">
             <div class="modal-content wide card">
-                <span class="heading">User profiles <span class="modal-close">&times;</span></span>
-                <p class="support lg">Profiles are applied to users when they create an account. A profile includes library access rights and homescreen layout.</p>
+                <span class="heading">{{ .strings.userProfiles }} <span class="modal-close">&times;</span></span>
+                <p class="support lg">{{ .strings.userProfilesDescription }}</p>
                 <div class="table-responsive">
                     <table class="table">
                         <thead>
                             <tr>
-                                <th>Name</th>
-                                <th>Default</th>
-                                <th>From</th>
-                                <th>Libraries</th>
-                                <th><span class="button ~neutral !high" id="button-profile-create">Create</span></th>
+                                <th>{{ .strings.name }}</th>
+                                <th>{{ .strings.userProfilesIsDefault }}</th>
+                                <th>{{ .strings.from }}</th>
+                                <th>{{ .strings.userProfilesLibraries }}</th>
+                                <th><span class="button ~neutral !high" id="button-profile-create">{{ .strings.create }}</span></th>
                             </tr>
                         </thead>
-                        <tbody id="table-profiles">
-                        </tbody>
+                        <tbody id="table-profiles"></tbody>
                     </table>
                 </div>
             </div>
         </div>
         <div id="modal-add-profile" class="modal">
             <form class="modal-content card" id="form-add-profile" href="">
-                <span class="heading">Add profile <span class="modal-close">&times;</span></span>
-                <p class="content">Create a Jellyfin user and configure it. Select it here, and when this profile is applied to an invite, new users will be created with its settings.</p>
+                <span class="heading">{{ .strings.addProfile }} <span class="modal-close">&times;</span></span>
+                <p class="content">{{ .strings.addProfileDescription }}</p>
                 <label>
-                    <span class="supra">Profile Name </span>
-                    <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="Name" id="add-profile-name">
+                    <span class="supra">{{ .strings.addProfileNameOf }} </span>
+                    <input type="text" class="field input ~neutral !high mt-half mb-1" placeholder="{{ .strings.name }}" id="add-profile-name">
                 <label>
-                    <span class="supra">User</span>
+                    <span class="supra">{{ .strings.user }}</span>
                     <div class="select ~neutral !normal mt-half mb-1">
-                        <select id="add-profile-user">
-                        </select>
+                        <select id="add-profile-user"></select>
                     </div>
                 </label>
                 <label class="switch mb-1">
                     <input type="checkbox" id="add-profile-homescreen" checked>
-                    <span>Store homescreen layout</span>
+                    <span>{{ .strings.addProfileStoreHomescreenLayout }}</span>
                 </label>
                 <label>
                     <input type="submit" class="unfocused">
-                    <span class="button ~urge !normal full-width center supra submit">Create</span>
+                    <span class="button ~urge !normal full-width center supra submit">{{ .strings.create }}</span>
                 </label>
             </form>
         </div>
@@ -182,40 +170,40 @@
             <div class="mb-1">
                 <header class="flex flex-wrap items-center justify-between">
                     <div class="text-neutral-700">
-                        <span id="button-tab-invites" class="tab-button portal">Invites</span>
-                        <span id="button-tab-accounts" class="tab-button portal">Accounts</span>
-                        <span id="button-tab-settings" class="tab-button portal">Settings</span>
+                        <span id="button-tab-invites" class="tab-button portal">{{ .strings.invites }}</span>
+                        <span id="button-tab-accounts" class="tab-button portal">{{ .strings.accounts }}</span>
+                        <span id="button-tab-settings" class="tab-button portal">{{ .strings.settings }}</span>
                     </div>
                 </header>
             </div>
             <div class="mb-1">
                 <div class="text-neutral-700">
-                    <span class="button ~critical !normal mb-1 unfocused" id="logout-button">Logout</span>
-                    <span id="button-theme" class="button ~neutral !normal mb-1">Theme</span>
+                    <span class="button ~critical !normal mb-1 unfocused" id="logout-button">{{ .strings.logout }}</span>
+                    <span id="button-theme" class="button ~neutral !normal mb-1">{{ .strings.theme }}</span>
                 </div>
             </div>
             <div id="tab-invites">
                 <div class="card ~neutral !low invites mb-1">
-                    <span class="heading">Invites</span>
+                    <span class="heading">{{ .strings.invites }}</span>
                     <div id="invites"></div>
                 </div>
                 <div class="card ~neutral !low">
-                    <span class="heading">Create</span>
+                    <span class="heading">{{ .strings.create }}</span>
                     <div class="row" id="create-inv">
                         <div class="card ~neutral !normal col">
-                            <label class="label supra" for="create-days">Days</label>
+                            <label class="label supra" for="create-days">{{ .strings.inviteDays }}</label>
                             <div class="select ~neutral !normal mb-1 mt-half">
                                 <select id="create-days">
                                     <option>0</option>
                                 </select>
                             </div>
-                            <label class="label supra" for="create-hours">Hours</label>
+                            <label class="label supra" for="create-hours">{{ .strings.inviteHours }}</label>
                             <div class="select ~neutral !normal mb-1 mt-half">
                                 <select id="create-hours">
                                     <option>0</option>
                                 </select>
                             </div>
-                            <label class="label supra" for="create-minutes">Minutes</label>
+                            <label class="label supra" for="create-minutes">{{ .strings.inviteMinutes }}</label>
                             <div class="select ~neutral !normal mb-1 mt-half">
                                 <select id="create-minutes">
                                     <option>0</option>
@@ -223,7 +211,7 @@
                             </div>
                         </div>
                         <div class="card ~neutral !normal col">
-                            <label class="label supra" for="create-uses">Number of uses</label>
+                            <label class="label supra" for="create-uses">{{ .strings.inviteNumberOfUses }}</label>
                             <div class="flex-expand mb-1 mt-half">
                                 <input type="number" min="0" id="create-uses" class="input ~neutral !normal mr-1" value=1>
                                 <label for="create-inf-uses" class="button ~neutral !normal">
@@ -231,14 +219,14 @@
                                     <input type="checkbox" class="unfocused" id="create-inf-uses" aria-label="Set uses to infinite">
                                 </label>
                             </div>
-                            <p class="support unfocused" id="create-inf-uses-warning"><span class="badge ~critical">Warning</span> invites with infinite uses can be used abusively.</p>
-                            <label class="label supra">Profile</label>
+                            <p class="support unfocused" id="create-inf-uses-warning"><span class="badge ~critical">{{ .strings.warning }}</span> {{ .strings.inviteInfiniteUsesWarning }}</p>
+                            <label class="label supra">{{ .strings.profile }}</label>
                             <div class="select ~neutral !normal mb-1 mt-half">
                                 <select id="create-profile">
                                 </select>
                             </div>
                             <div id="create-send-to-container">
-                                <label class="label supra">Send to</label>
+                                <label class="label supra">{{ .strings.inviteSendToEmail }}</label>
                                 <div class="flex-expand mb-1 mt-half">
                                     <input type="email" id="create-send-to" class="input ~neutral !normal mr-1" placeholder="example@example.com">
                                     <label for="create-send-to-enabled" class="button ~neutral !normal">
@@ -246,27 +234,27 @@
                                     </label>
                                 </div>
                             </div>
-                            <span class="button ~urge !normal supra full-width center lg" id="create-submit">Create</span>
+                            <span class="button ~urge !normal supra full-width center lg" id="create-submit">{{ .strings.create }}</span>
                         </div>
                     </div>
                 </div>
             </div>
             <div id="tab-accounts" class="unfocused">
                 <div class="card ~neutral !low accounts mb-1">
-                    <span class="heading">Accounts</span>
+                    <span class="heading">{{ .strings.accounts }}</span>
                     <div class="fr">
-                        <span class="button ~neutral !normal" id="accounts-add-user">Add User</span>
-                        <span class="button ~urge !normal" id="accounts-modify-user">Modify Settings</span>
-                        <span class="button ~critical !normal" id="accounts-delete-user">Delete User</span>
+                        <span class="button ~neutral !normal" id="accounts-add-user">{{ .quantityStrings.addUser.singular }}</span>
+                        <span class="button ~urge !normal" id="accounts-modify-user">{{ .strings.modifySettings }}</span>
+                        <span class="button ~critical !normal" id="accounts-delete-user">{{ .quantityStrings.deleteUser.singular }}</span>
                     </div>
                     <div class="card ~neutral !normal accounts-header table-responsive mt-half">
                         <table class="table">
                             <thead>
                                 <tr>
                                     <th><input type="checkbox" value="" id="accounts-select-all"></th>
-                                    <th>Username</th>
-                                    <th>Email Address</th>
-                                    <th>Last Active</th>
+                                    <th>{{ .strings.username }}</th>
+                                    <th>{{ .strings.emailAddress }}</th>
+                                    <th>{{ .strings.lastActiveTime }}</th>
                                 </tr>
                             </thead>
                             <tbody id="accounts-list"></tbody>
@@ -276,15 +264,15 @@
             </div>
             <div id="tab-settings" class="unfocused">
                 <div class="card ~neutral !low settings overflow">
-                    <span class="heading">Settings</span>
+                    <span class="heading">{{ .string.settings }}</span>
                     <div class="fr">
-                        <span class="button ~neutral !normal unfocused" id="settings-save">Save</span>
+                        <span class="button ~neutral !normal unfocused" id="settings-save">{{ .strings.settingsSave }}</span>
                     </div>
                     <div class="row">
                         <div class="card ~neutral !normal col" id="settings-sidebar">
-                            <aside class="aside sm ~info mb-half">Note: <span class="badge ~critical">*</span> indicates a required field, <span class="badge ~info">R</span> indicates changes require a restart.</aside> 
-                            <span class="button ~neutral !low settings-section-button mb-half" id="setting-about"><span class="flex">About <i class="ri-information-line ml-half"></i></span></span>
-                            <span class="button ~neutral !low settings-section-button mb-half" id="setting-profiles"><span class="flex">User profiles <i class="ri-user-line ml-half"></i></span></span>
+                            <aside class="aside sm ~info mb-half" id="settings-message">Note: <span class="badge ~critical">*</span> indicates a required field, <span class="badge ~info">R</span> indicates changes require a restart.</aside> 
+                            <span class="button ~neutral !low settings-section-button mb-half" id="setting-about"><span class="flex">{{ .strings.aboutProgram }} <i class="ri-information-line ml-half"></i></span></span>
+                            <span class="button ~neutral !low settings-section-button mb-half" id="setting-profiles"><span class="flex">{{ .strings.userProfiles }} <i class="ri-user-line ml-half"></i></span></span>
                         </div>
                         <div class="card ~neutral !normal col overflow" id="settings-panel"></div>
                     </div>

--- a/lang/admin/README.md
+++ b/lang/admin/README.md
@@ -1,5 +1,0 @@
-##### admin page translation
-
-* [x] static page content
-* [ ] Typescript:
-    * [x] accounts.ts

--- a/lang/admin/README.md
+++ b/lang/admin/README.md
@@ -1,0 +1,5 @@
+##### admin page translation
+
+* [x] static page content
+* [ ] Typescript:
+    * [x] accounts.ts

--- a/lang/admin/en-us.json
+++ b/lang/admin/en-us.json
@@ -1,0 +1,80 @@
+{
+    "meta": {
+        "name": "English (US)"
+    },
+    "strings": {
+        "invites": "Invites",
+        "accounts": "Accounts",
+        "settings": "Settings",
+        "theme": "Theme",
+        "inviteDays": "Days",
+        "inviteHours": "Hours",
+        "inviteMinutes": "Minutes",
+        "inviteNumberOfUses": "Number of uses",
+        "warning": "Warning",
+        "inviteInfiniteUsesWarning": "invites with infinite uses can be used abusively",
+        "inviteSendToEmail": "Send to",
+        "login": "Login",
+        "logout": "Logout",
+        "create": "Create",
+        "apply": "Apply",
+        "delete": "Delete",
+        "submit": "Submit",
+        "name": "Name",
+        "username": "Username",
+        "password": "Password",
+        "emailAddress": "Email Address",
+        "lastActiveTime": "Last Active",
+        "from": "From",
+        "user": "User",
+        "aboutProgram": "About",
+        "version": "Version",
+        "commitNoun": "Commit",
+        "newUser": "New User",
+        "profile": "Profile",
+        "modifySettings": "Modify Settings",
+        "modifySettingsDescription": "Apply settings from an existing profile, or source them directly from a user.",
+        "applyHomescreenLayout": "Apply homescreen layout",
+        "sendDeleteNotificationEmail": "Send notification email",
+        "sendDeleteNotifiationExample": "Your account has been deleted.",
+        "settingsRestartRequired": "Restart needed",
+        "settingsRestartRequiredDescription": "A restart is necessary to apply some settings you changed. Restart now or later?",
+        "settingsApplyRestartLater": "Apply, restart later",
+        "settingsApplyRestartNow": "Apply & restart",
+        "settingsApplied": "Settings applied.",
+        "settingsRefreshPage": "Refresh the page in a few seconds",
+        "settingsRequiredOrRestartMessage": "Note: {*} indicates a required field, {R} indicates changes require a restart.",
+        "settingsSave": "Save",
+        "ombiUserDefaults": "Ombi user defaults",
+        "ombiUserDefaultsDescription": "Create an Ombi user and configure it, then select it below. It's settings/permissions will be stored and applied to new Ombi users created by jfa-go",
+        "userProfiles": "User Profiles",
+        "userProfilesDescription": "Profiles are applied to users when they create an account. A profile include library access rights and homescreen layout.",
+        "userProfilesIsDefault": "Default",
+        "userProfilesLibraries": "Libraries",
+        "addProfile": "Add Profile",
+        "addProfileDescription": "Create a Jellyfin user and configure it, then select it below. When this profile is applied to an invite, new users will be created with the settings.",
+        "addProfileNameOf": "Profile Name",
+        "addProfileStoreHomescreenLayout": "Store homescreen layout"
+    },
+    "variableStrings": {
+        "settingsRequiredOrRestartMessage": "Note: {*} indicates a required field, {R} indicates changes require a restart."
+    },
+    "quantityStrings": {
+        "modifySettingsFor": {
+            "singular": "Modify Settings for {n} user",
+            "plural": "Modify Settings for {n} users"
+        },
+        "deleteNUsers": {
+            "singular": "Delete {n} user",
+            "plural": "Delete {n} users"
+        },
+        "addUser": {
+            "singular": "Add user",
+            "plural": "Add users"
+        },
+        "deleteUser": {
+            "singular": "Delete User",
+            "plural": "Delete Users"
+        }
+    }
+}

--- a/lang/admin/en-us.json
+++ b/lang/admin/en-us.json
@@ -21,6 +21,7 @@
         "delete": "Delete",
         "submit": "Submit",
         "name": "Name",
+        "date": "Date",
         "username": "Username",
         "password": "Password",
         "emailAddress": "Email Address",
@@ -32,6 +33,9 @@
         "commitNoun": "Commit",
         "newUser": "New User",
         "profile": "Profile",
+        "success": "Success",
+        "error": "Error",
+        "unknown": "Unknown",
         "modifySettings": "Modify Settings",
         "modifySettingsDescription": "Apply settings from an existing profile, or source them directly from a user.",
         "applyHomescreenLayout": "Apply homescreen layout",
@@ -43,7 +47,7 @@
         "settingsApplyRestartNow": "Apply & restart",
         "settingsApplied": "Settings applied.",
         "settingsRefreshPage": "Refresh the page in a few seconds",
-        "settingsRequiredOrRestartMessage": "Note: {*} indicates a required field, {R} indicates changes require a restart.",
+        "settingsRequiredOrRestartMessage": "Note: {n} indicates a required field, {n} indicates changes require a restart.",
         "settingsSave": "Save",
         "ombiUserDefaults": "Ombi user defaults",
         "ombiUserDefaultsDescription": "Create an Ombi user and configure it, then select it below. It's settings/permissions will be stored and applied to new Ombi users created by jfa-go",
@@ -54,11 +58,49 @@
         "addProfile": "Add Profile",
         "addProfileDescription": "Create a Jellyfin user and configure it, then select it below. When this profile is applied to an invite, new users will be created with the settings.",
         "addProfileNameOf": "Profile Name",
-        "addProfileStoreHomescreenLayout": "Store homescreen layout"
+        "addProfileStoreHomescreenLayout": "Store homescreen layout",
+        
+        "inviteNoUsersCreated": "None yet!",
+        "inviteUsersCreated": "Created users",
+        "inviteNoProfile": "No Profile",
+        "copy": "Copy",
+        "inviteDateCreated": "Created",
+        "inviteRemainingUses": "Remaining uses",
+        "inviteNoInvites": "None",
+        "inviteExpiresInTime": "Expires in {n}",
+
+        "notifyEvent": "Notify on:",
+        "notifyInviteExpiry": "On expiry",
+        "notifyUserCreation": "On user creation"
     },
-    "variableStrings": {
-        "settingsRequiredOrRestartMessage": "Note: {*} indicates a required field, {R} indicates changes require a restart."
+    "notifications": {
+        "changedEmailAddress": "Changed email address of {n}.",
+        "userCreated": "User {n} created.",
+        "createProfile": "Created profile {n}.",
+        "saveSettings": "Settings were saved",
+        "setOmbiDefaults": "Stored ombi defaults.",
+        "errorConnection": "Couldn't connect to jfa-go.",
+        "error401Unauthorized": "Unauthorized. Try refreshing the page.",
+        "errorSettingsAppliedNoHomescreenLayout": "Settings were applied, but applying homescreen layout may have failed.",
+        "errorHomescreenAppliedNoSettings": "Homescreen layout was applied, but applying settings may have failed.",
+        "errorSettingsFailed": "Application failed.",
+        "errorLoginBlank": "The username and/or password were left blank.",
+        "errorUnknown": "Unknown error.",
+        "errorBlankFields": "Fields were left blank",
+        "errorDeleteProfile": "Failed to delete profile {n}",
+        "errorLoadProfiles": "Failed to load profiles.",
+        "errorCreateProfile": "Failed to create profile {n}",
+        "errorSetDefaultProfile": "Failed to set default profile.",
+        "errorLoadUsers": "Failed to load users.",
+        "errorSaveSettings": "Couldn't save settings.",
+        "errorLoadSettings": "Failed to load settings.",
+        "errorSetOmbiDefaults": "Failed to store ombi defaults.",
+        "errorLoadOmbiUsers": "Failed to load ombi users.",
+        "errorChangedEmailAddress": "Couldn't change email address of {n}.",
+        "errorFailureCheckLogs": "Failed (check console/logs)",
+        "errorPartialFailureCheckLogs": "Partial failure (check console/logs)"
     },
+
     "quantityStrings": {
         "modifySettingsFor": {
             "singular": "Modify Settings for {n} user",
@@ -75,6 +117,14 @@
         "deleteUser": {
             "singular": "Delete User",
             "plural": "Delete Users"
+        },
+        "deletedUser": {
+            "singular": "Deleted {n} user.",
+            "plural": "Deleted {n} users."
+        },
+        "appliedSettings": {
+            "singular": "Applied settings to {n} user.",
+            "plural": "Applied settings to {n} users."
         }
     }
 }

--- a/lang/admin/fr-fr.json
+++ b/lang/admin/fr-fr.json
@@ -22,17 +22,21 @@
         "delete": "Effacer",
         "submit": "Soumettre",
         "name": "Nom",
+        "date": "Date",
         "username": "Nom d'utilisateur",
         "password": "Mot de passe",
         "emailAddress": "Addresse Email",
         "lastActiveTime": "Dernière activité",
         "from": "De",
         "user": "Utilisateur",
-        "aboutProgram": "A propros",
+        "aboutProgram": "A propos",
         "version": "Version",
         "commitNoun": "Commettre",
         "newUser": "Nouvel utilisateur",
         "profile": "Profil",
+        "success": "Succès",
+        "error": "Erreur",
+        "unknown": "Inconnu",
         "modifySettings": "Modifier les paramètres",
         "modifySettingsDescription": "Appliquez les paramètres à partir d'un profil existant ou obtenez-les directement auprès d'un utilisateur.",
         "applyHomescreenLayout": "Appliquer la disposition de l'écran d'accueil",
@@ -55,7 +59,47 @@
         "addProfile": "Ajouter un profil",
         "addProfileDescription": "Créez un utilisateur Jellyfin et configurez-le, puis sélectionnez-le ci-dessous. Lorsque ce profil est appliqué à une invitation, de nouveaux utilisateurs seront créés avec les paramètres. ",
         "addProfileNameOf": "Nom de profil",
-        "addProfileStoreHomescreenLayout": "Enregistrer la disposition de l'écran d'accueil"
+        "addProfileStoreHomescreenLayout": "Enregistrer la disposition de l'écran d'accueil",
+    
+        "inviteNoUsersCreated": "Aucun pour l'instant!",
+        "inviteUsersCreated": "Utilisateurs créer",
+        "inviteNoProfile": "Aucun profil",
+        "copy": "Copier",
+        "inviteDateCreated": "Créer",
+        "inviteRemainingUses": "Utilisations restantes",
+        "inviteNoInvites": "Aucune",
+        "inviteExpiresInTime": "Expires dans {n}",
+
+        "notifyEvent": "Notifier sur:",
+        "notifyInviteExpiry": "À l'expiration",
+        "notifyUserCreation": "à la création de l'utilisateur"
+    },
+    "notifications": {
+        "changedEmailAddress": "Adresse e-mail modifiée de {n}.",
+        "userCreated": "L'utilisateur {n} a été créé.",
+        "createProfile": "Profil créé {n}.",
+        "saveSettings": "Les paramètres ont été enregistrés",
+        "setOmbiDefaults": "Valeurs par défaut de Ombi.",
+        "errorConnection": "Impossible de se connecter à jfa-go.",
+        "error401Unauthorized": "Non autorisé. Essayez d'actualiser la page.",
+        "errorSettingsAppliedNoHomescreenLayout": "Les paramètres ont été appliqués, mais l'application de la disposition de l'écran d'accueil a peut-être échoué.",
+        "errorHomescreenAppliedNoSettings": "La disposition de l'écran d'accueil a été appliquée, mais l'application des paramètres a peut-être échoué.",
+        "errorSettingsFailed": "L'application a échoué.",
+        "errorLoginBlank": "Le nom d'utilisateur et / ou le mot de passe sont vides",
+        "errorUnknown": "Erreur inconnue.",
+        "errorBlankFields": "Les champs sont vides",
+        "errorDeleteProfile": "Échec de la suppression du profil {n}",
+        "errorLoadProfiles": "Échec du chargement des profils.",
+        "errorCreateProfile": "Échec de la création du profil {n}",
+        "errorSetDefaultProfile": "Échec de la définition du profil par défaut",
+        "errorLoadUsers": "Échec du chargement des utilisateurs.",
+        "errorSaveSettings": "Impossible d'enregistrer les paramètres.",
+        "errorLoadSettings": "Échec du chargement des paramètres.",
+        "errorSetOmbiDefaults": "Impossible de stocker les valeurs par défaut d'Ombi.",
+        "errorLoadOmbiUsers": "Échec du chargement des utilisateurs Ombi.",
+        "errorChangedEmailAddress": "Impossible de modifier l'adresse e-mail de {n}.",
+        "errorFailureCheckLogs": "Échec (vérifier la console / les journaux)",
+        "errorPartialFailureCheckLogs": "Panne partielle (vérifier la console / les journaux)"
     },
     "quantityStrings": {
         "modifySettingsFor": {
@@ -73,6 +117,14 @@
         "deleteUser": {
             "singular": "Supprimer l'utilisateur",
             "plural": "Supprimer les utilisateurs"
+        },
+        "deletedUser": {
+          "singular": "Supprimer {n} utilisateur.",
+          "plural": "Supprimer {n} utilisateurs."
+        },
+        "appliedSettings": {
+          "singular": "Appliquer le paramètre {n} utilisteur.",
+          "plural": "Appliquer les paramètres {n} utilisteurs."
         }
     }
 }

--- a/lang/admin/fr-fr.json
+++ b/lang/admin/fr-fr.json
@@ -1,0 +1,78 @@
+{
+    "meta": {
+        "name": "Francais (FR)",
+        "author": "https://github.com/Killianbe"
+    },
+    "strings": {
+        "invites": "Invite",
+        "accounts": "Comptes",
+        "settings": "Reglages",
+        "theme": "Thème",
+        "inviteDays": "Jours",
+        "inviteHours": "Heures",
+        "inviteMinutes": "Minutes",
+        "inviteNumberOfUses": "Nombre d'utilisateur",
+        "warning": "Attention",
+        "inviteInfiniteUsesWarning": "les invitations infinies peuvent être utilisées abusivement",
+        "inviteSendToEmail": "Envoyer à",
+        "login": "S'identifier",
+        "logout": "Se déconecter",
+        "create": "Créer",
+        "apply": "Appliquer",
+        "delete": "Effacer",
+        "submit": "Soumettre",
+        "name": "Nom",
+        "username": "Nom d'utilisateur",
+        "password": "Mot de passe",
+        "emailAddress": "Addresse Email",
+        "lastActiveTime": "Dernière activité",
+        "from": "De",
+        "user": "Utilisateur",
+        "aboutProgram": "A propros",
+        "version": "Version",
+        "commitNoun": "Commettre",
+        "newUser": "Nouvel utilisateur",
+        "profile": "Profil",
+        "modifySettings": "Modifier les paramètres",
+        "modifySettingsDescription": "Appliquez les paramètres à partir d'un profil existant ou obtenez-les directement auprès d'un utilisateur.",
+        "applyHomescreenLayout": "Appliquer la disposition de l'écran d'accueil",
+        "sendDeleteNotificationEmail": "Envoyer un e-mail de notification ",
+        "sendDeleteNotifiationExample": "Votre compte a été supprimé. ",
+        "settingsRestartRequired": "Redémarrage nécessaire ",
+        "settingsRestartRequiredDescription": "Un redémarrage est nécessaire pour appliquer certains paramètres que vous avez modifiés. Redémarrer maintenant ou plus tard?",
+        "settingsApplyRestartLater": "Appliquer, redémarrer plus tard ",
+        "settingsApplyRestartNow": "Appliquer et redémarrer ",
+        "settingsApplied": "Paramètres appliqués.",
+        "settingsRefreshPage": "Actualisez la page dans quelques secondes ",
+        "settingsRequiredOrRestartMessage": "Remarque: {n} indique un champ obligatoire, {n} indique que les modifications nécessitent un redémarrage. ",
+        "settingsSave": "Sauver",
+        "ombiUserDefaults": "Paramètres par défaut de l'utilisateur Ombi",
+        "ombiUserDefaultsDescription": "Créez un utilisateur Ombi et configurez-le, puis sélectionnez-le ci-dessous. Ses paramètres / autorisations seront stockés et appliqués aux nouveaux utilisateurs Ombi créés par jfa-go ",
+        "userProfiles": "Profils d'utilisateurs",
+        "userProfilesDescription": "Les profils sont appliqués aux utilisateurs lorsqu'ils créent un compte. Un profil inclut les droits d'accès à la bibliothèque et la disposition de l'écran d'accueil. ",
+        "userProfilesIsDefault": "Défaut",
+        "userProfilesLibraries": "Bibliothèques",
+        "addProfile": "Ajouter un profil",
+        "addProfileDescription": "Créez un utilisateur Jellyfin et configurez-le, puis sélectionnez-le ci-dessous. Lorsque ce profil est appliqué à une invitation, de nouveaux utilisateurs seront créés avec les paramètres. ",
+        "addProfileNameOf": "Nom de profil",
+        "addProfileStoreHomescreenLayout": "Enregistrer la disposition de l'écran d'accueil"
+    },
+    "quantityStrings": {
+        "modifySettingsFor": {
+            "singular": "Modifier les paramètres pour {n} utilisateur",
+            "plural": "Modifier les paramètres pour {n} utilisateurs"
+        },
+        "deleteNUsers": {
+            "singular": "Supprimer {n} utilisateur",
+            "plural": "Supprimer {n} utilisateurs"
+        },
+        "addUser": {
+            "singular": "Ajouter un utilisateur",
+            "plural": "Ajouter des utilisateurs"
+        },
+        "deleteUser": {
+            "singular": "Supprimer l'utilisateur",
+            "plural": "Supprimer les utilisateurs"
+        }
+    }
+}

--- a/lang/email/en-us.json
+++ b/lang/email/en-us.json
@@ -1,0 +1,41 @@
+{
+    "meta": {
+        "name": "English (US)"
+    },
+    "userCreated": {
+        "title": "Notice: User created",
+        "aUserWasCreated": "A user was created using code {n}.",
+        "name": "Name",
+        "emailAddress": "Address",
+        "time": "Time",
+        "notificationNotice": "Note: Notification emails can be toggled on the admin dashboard."
+    },
+    "inviteExpiry": {
+        "title": "Notice: Invite expired",
+        "inviteExpired": "Invite expired.",
+        "expiredAt": "Code {n} expired at {n}.",
+        "notificationNotice": "Note: Notification emails can be toggled on the admin dashboard."
+    },
+    "passwordReset": {
+        "title": "Password reset requested - Jellyfin",
+        "helloUser": "Hi {n},",
+        "someoneHasRequestedReset": "Someone has recently requested a password reset on Jellyfin.",
+        "ifItWasYou": "If this was you, enter the pin below into the prompt.",
+        "codeExpiry": "The code will expire on {n}, at {n} UTC, which is in {n}.",
+        "ifItWasNotYou": "If this wasn't you, please ignore this email.",
+        "pin": "PIN"
+    },
+    "userDeleted": {
+        "title": "Your account was deleted - Jellyfin",
+        "yourAccountWasDeleted": "Your Jellyfin account was deleted.",
+        "reason": "Reason"
+    },
+    "inviteEmail": {
+        "title": "Invite - Jellyfin",
+        "hello": "Hi",
+        "youHaveBeenInvited": "You've been invited to Jellyfin.",
+        "toJoin": "To join, follow the below link.",
+        "inviteExpiry": "This invite will expire on {n}, at {n}, which is in {n}, so act quick.",
+        "linkButton": "Setup your account"
+    }
+}

--- a/lang/email/fr-fr.json
+++ b/lang/email/fr-fr.json
@@ -1,0 +1,32 @@
+{
+    "meta": {
+        "name": "Francais (FR)",
+        "author": "https://github.com/Cornichon420"
+    },
+    "userCreated": {
+        "aUserWasCreated": "Un utilisateur a été créé avec ce code {n}",
+        "name": "Nom",
+        "emailAddress": "Adresse",
+        "time": "Date",
+        "notificationNotice": ""
+    },
+    "passwordReset": {
+        "helloUser": "Salut {n},",
+        "someoneHasRequestedReset": "Quelqu'un vient de demander une réinitialisation du mot de passe via Jellyfin.",
+        "ifItWasYou": "Si c'était bien toi, renseigne le code PIN en dessous.",
+        "codeExpiry": "Ce code expirera le {n}, à {n} UTC, soit dans {n}.",
+        "ifItWasNotYou": "Si ce n'était pas toi, tu peux ignorer ce mail.",
+        "pin": "PIN"
+    },
+    "userDeleted": {
+        "yourAccountWasDeleted": "Ton compte Jellyfin a été supprimé.",
+        "reason": "Motif"
+    },
+    "inviteEmail": {
+        "hello": "Salut",
+        "youHaveBeenInvited": "Tu a été invité à rejoindre Jellyfin.",
+        "toJoin": "Pour continuer, suis le lien en dessous.",
+        "inviteExpiry": "L'invitation expirera le {n}, à {n}, sout dans {n}, alors fais vite !",
+        "linkButton": "Lien"
+    }
+}

--- a/lang/email/fr-fr.json
+++ b/lang/email/fr-fr.json
@@ -18,7 +18,7 @@
         "notificationNotice": ""
     },
     "passwordReset": {
-        "title": "Réinitialisation de mot de passe demandée - Jellyfin",
+        "title": "Réinitialisation de mot du passe demandée - Jellyfin",
         "helloUser": "Salut {n},",
         "someoneHasRequestedReset": "Quelqu'un vient de demander une réinitialisation du mot de passe via Jellyfin.",
         "ifItWasYou": "Si c'était bien toi, renseigne le code PIN en dessous.",
@@ -34,9 +34,9 @@
     "inviteEmail": {
         "title": "Invitation - Jellyfin",
         "hello": "Salut",
-        "youHaveBeenInvited": "Tu a été invité à rejoindre Jellyfin.",
+        "youHaveBeenInvited": "Tu as été invité à rejoindre Jellyfin.",
         "toJoin": "Pour continuer, suis le lien en dessous.",
-        "inviteExpiry": "L'invitation expirera le {n}, à {n}, sout dans {n}, alors fais vite !",
+        "inviteExpiry": "L'invitation expirera le {n}, à {n}, soit dans {n}, alors fais vite !",
         "linkButton": "Lien"
     }
 }

--- a/lang/email/fr-fr.json
+++ b/lang/email/fr-fr.json
@@ -4,13 +4,21 @@
         "author": "https://github.com/Cornichon420"
     },
     "userCreated": {
+        "title": "Notification : Utilisateur créé",
         "aUserWasCreated": "Un utilisateur a été créé avec ce code {n}",
         "name": "Nom",
         "emailAddress": "Adresse",
         "time": "Date",
         "notificationNotice": ""
     },
+    "inviteExpiry": {
+        "title": "Notification : Invitation expirée",
+        "inviteExpired": "Invitation expirée.",
+        "expiredAt": "Le code {n} a expiré à {n}.",
+        "notificationNotice": ""
+    },
     "passwordReset": {
+        "title": "Réinitialisation de mot de passe demandée - Jellyfin",
         "helloUser": "Salut {n},",
         "someoneHasRequestedReset": "Quelqu'un vient de demander une réinitialisation du mot de passe via Jellyfin.",
         "ifItWasYou": "Si c'était bien toi, renseigne le code PIN en dessous.",
@@ -19,10 +27,12 @@
         "pin": "PIN"
     },
     "userDeleted": {
+        "title": "Ton compte a été désactivé - Jellyfin",
         "yourAccountWasDeleted": "Ton compte Jellyfin a été supprimé.",
         "reason": "Motif"
     },
     "inviteEmail": {
+        "title": "Invitation - Jellyfin",
         "hello": "Salut",
         "youHaveBeenInvited": "Tu a été invité à rejoindre Jellyfin.",
         "toJoin": "Pour continuer, suis le lien en dessous.",

--- a/mail/created.mjml
+++ b/mail/created.mjml
@@ -20,26 +20,25 @@
     <mj-section mj-class="bg">
       <mj-column>
         <mj-text mj-class="text" font-size="16px" font-family="Noto Sans, Helvetica, Arial, sans-serif">
-          <h3>User Created</h3>
-          <p>A user was created using code {{ .code }}.</p>
+            <p>{{ .aUserWasCreated }}</p>
         </mj-text>
         <mj-table mj-class="text" container-background-color="#242424">
           <tr style="text-align: left;">
-            <th>Name</th>
-            <th>Address</th>
-            <th>Time</th>
+              <th>{{ .name }}</th>
+              <th>{{ .address }}</th>
+              <th>{{ .time }}</th>
           </tr>
           <tr style="font-style: italic; text-align: left; color: rgb(153,153,153);">
-            <th>{{ .username }}</th>
-            <th>{{ .address }}</th>
-            <th>{{ .time }}</th>
+            <th>{{ .nameVal }}</th>
+            <th>{{ .addressVal }}</th>
+            <th>{{ .timeVal }}</th>
         </mj-table>
       </mj-column>
     </mj-section>
     <mj-section mj-class="bg2">
       <mj-column>
         <mj-text mj-class="secondary" font-style="italic" font-size="14px">
-          Notification emails can be toggled on the admin dashboard.
+            {{ .notificationNotice }}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/mail/created.txt
+++ b/mail/created.txt
@@ -1,7 +1,7 @@
-A user was created using code {{ .code }}.
+{{ .aUserWasCreated }}
 
-Name: {{ .username }}
-Address: {{ .address }}
-Time: {{ .time }}
+{{ .name }}: {{ .nameVal }}
+{{ .address }}: {{ .addressVal }}
+{{ .time }}: {{ .timeVal }}
 
-Note: Notification emails can be toggled on the admin dashboard.
+{{ .notificationNotice }}

--- a/mail/deleted.mjml
+++ b/mail/deleted.mjml
@@ -20,8 +20,8 @@
     <mj-section mj-class="bg">
       <mj-column>
         <mj-text mj-class="text" font-size="16px" font-family="Noto Sans, Helvetica, Arial, sans-serif">
-          <h3>Your account was deleted.</h3>
-          <p>Reason: <i>{{ .reason }}</i></p>
+            <h3>{{ .yourAccountWasDeleted }}</h3>
+            <p>{{ .reason }}: <i>{{ .reasonVal }}</i></p>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/mail/deleted.txt
+++ b/mail/deleted.txt
@@ -1,4 +1,4 @@
-Your Jellyfin account was deleted.
-Reason: {{ .reason }}
+{{ .yourAccountWasDeleted }}
+{{ .reason }}: {{ .reasonVal }}
 
 {{ .message }}

--- a/mail/email.mjml
+++ b/mail/email.mjml
@@ -20,13 +20,13 @@
     <mj-section mj-class="bg">
       <mj-column>
         <mj-text mj-class="text" font-size="16px" font-family="Noto Sans, Helvetica, Arial, sans-serif">
-          <p>Hi {{ .username }},</p>
-          <p> Someone has recently requested a password reset on Jellyfin.</p>
-          <p>If this was you, enter the below pin into the prompt.</p>
-          <p>The code will expire on {{ .expiry_date }}, at {{ .expiry_time }} UTC, which is in {{ .expires_in }}.</p>
-          <p>If this wasn't you, please ignore this email.</p>
+            <p>{{ .helloUser }}</p>
+            <p>{{ .someoneHasRequestedReset }}</p>
+            <p>{{ .ifItWasYou }}</p>
+            <p>{{ .codeExpiry }}</p>
+            <p>{{ .ifItWasNotYou }}</p>
         </mj-text>
-        <mj-button mj-class="blue bold">{{ .pin }}</mj-button>
+        <mj-button mj-class="blue bold">{{ .pinVal }}</mj-button>
       </mj-column>
     </mj-section>
     <mj-section mj-class="bg2">

--- a/mail/email.txt
+++ b/mail/email.txt
@@ -1,10 +1,10 @@
-Hi {{ .username }},
+{{ .helloUser }}
 
-Someone has recently requests a password reset on Jellyfin.
-If this was you, enter the below pin into the prompt.
-This code will expire on {{ .expiry_date }}, at {{ .expiry_time }} UTC, which is in {{ .expires_in }}.
-If this wasn't you, please ignore this email.
+{{ .someoneHasRequestedReset }}
+{{ .ifItWasYou }}
+{{ .codeExpiry }}
+{{ .ifItWasNotYou }}
 
-PIN: {{ .pin }}
+{{ .pin }}: {{ .pinVal }}
 
 {{ .message }}

--- a/mail/expired.mjml
+++ b/mail/expired.mjml
@@ -20,15 +20,15 @@
     <mj-section mj-class="bg">
       <mj-column>
         <mj-text mj-class="text" font-size="16px" font-family="Noto Sans, Helvetica, Arial, sans-serif">
-          <h3>Invite Expired.</h3>
-          <p>Code {{ .code }} expired at {{ .expiry }}.</p>
+            <h3>{{ .inviteExpired }}</h3>
+            <p>{{ .expiredAt }}</p>
         </mj-text>
       </mj-column>
     </mj-section>
     <mj-section mj-class="bg2">
       <mj-column>
         <mj-text mj-class="secondary" font-style="italic" font-size="14px">
-          Notification emails can be toggled on the admin dashboard.
+            {{ .notificationNotice }}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/mail/expired.txt
+++ b/mail/expired.txt
@@ -1,5 +1,5 @@
-Invite expired.
+{{ .inviteExpired }}
 
-Code {{ .code }} expired at {{ .expiry }}.
+{{ .expiredAt }}
 
-Note: Notification emails can be toggled on the admin dashboard.
+{{ .notificationNotice }}

--- a/mail/invite-email.mjml
+++ b/mail/invite-email.mjml
@@ -20,12 +20,12 @@
     <mj-section mj-class="bg">
       <mj-column>
         <mj-text mj-class="text" font-size="16px" font-family="Noto Sans, Helvetica, Arial, sans-serif">
-          <p>Hi,</p>
-          <h3>You've been invited to Jellyfin.</h3>
-          <p>To join, click the button below.</p>
-          <p>This invite will expire on {{ .expiry_date }}, at {{ .expiry_time }}, which is in {{ .expires_in }}, so act quick.</p>
+            <p>{{ .hello }},</p>
+            <h3>{{ .youHaveBeenInvited }}</h3>
+            <p>{{ .toJoin }}</p>
+            <p>{{ .inviteExpiry }}</p>
         </mj-text>
-        <mj-button mj-class="blue bold" href="{{ .invite_link }}">Setup your account</mj-button>
+        <mj-button mj-class="blue bold" href="{{ .invite_link }}">{{ .linkButton }}</mj-button>
       </mj-column>
     </mj-section>
     <mj-section mj-class="bg2">

--- a/mail/invite-email.txt
+++ b/mail/invite-email.txt
@@ -1,7 +1,7 @@
-Hi,
-You've been invited to Jellyfin.
-To join, follow the below link.
-This invite will expire on {{ .expiry_date }}, at {{ .expiry_time }}, which is in {{ .expires_in }}, so act quick.
+{{ .hello }},
+{{ .youHaveBeenInvited }}
+{{ .toJoin }}
+{{ .inviteExpiry }}
 
 {{ .invite_link }}
 

--- a/main.go
+++ b/main.go
@@ -514,6 +514,7 @@ func start(asDaemon, firstCall bool) {
 			}
 		}
 		app.storage.lang.FormPath = filepath.Join(app.localPath, "lang", "form")
+		app.storage.lang.AdminPath = filepath.Join(app.localPath, "lang", "admin")
 		err = app.storage.loadLang()
 		if err != nil {
 			app.info.Fatalf("Failed to load language files: %+v\n", err)

--- a/main.go
+++ b/main.go
@@ -370,7 +370,6 @@ func start(asDaemon, firstCall bool) {
 
 		app.storage.profiles_path = app.config.Section("files").Key("user_profiles").String()
 		app.storage.loadProfiles()
-
 		if !(len(app.storage.policy) == 0 && len(app.storage.configuration) == 0 && len(app.storage.displayprefs) == 0) {
 			app.info.Println("Migrating user template files to new profile format")
 			app.storage.migrateToProfile()
@@ -515,6 +514,7 @@ func start(asDaemon, firstCall bool) {
 		}
 		app.storage.lang.FormPath = filepath.Join(app.localPath, "lang", "form")
 		app.storage.lang.AdminPath = filepath.Join(app.localPath, "lang", "admin")
+		app.storage.lang.EmailPath = filepath.Join(app.localPath, "lang", "email")
 		err = app.storage.loadLang()
 		if err != nil {
 			app.info.Fatalf("Failed to load language files: %+v\n", err)

--- a/main.go
+++ b/main.go
@@ -577,7 +577,7 @@ func start(asDaemon, firstCall bool) {
 		router.GET("/accounts", app.AdminPage)
 		router.GET("/settings", app.AdminPage)
 
-		router.GET("/lang", app.GetLanguages)
+		router.GET("/lang/:page", app.GetLanguages)
 		router.GET("/token/login", app.getTokenLogin)
 		router.GET("/token/refresh", app.getTokenRefresh)
 		router.POST("/newUser", app.NewUser)

--- a/ts/admin.ts
+++ b/ts/admin.ts
@@ -1,14 +1,25 @@
 import { toggleTheme, loadTheme } from "./modules/theme.js";
+import { lang, LangFile } from "./modules/lang.js";
 import { Modal } from "./modules/modal.js";
 import { Tabs } from "./modules/tabs.js";
 import { inviteList, createInvite } from "./modules/invites.js";
 import { accountsList } from "./modules/accounts.js";
 import { settingsList } from "./modules/settings.js";
 import { ProfileEditor } from "./modules/profiles.js";
-import { _post, notificationBox, whichAnimationEvent, toggleLoader } from "./modules/common.js";
+import { _get, _post, notificationBox, whichAnimationEvent, toggleLoader } from "./modules/common.js";
 
 loadTheme();
 (document.getElementById('button-theme') as HTMLSpanElement).onclick = toggleTheme;
+
+var langLoaded = false;
+
+window.lang = new lang(window.langFile as LangFile);
+// _get(`/lang/admin/${window.language}.json`, null, (req: XMLHttpRequest) => {
+//     if (req.readyState == 4 && req.status == 200) {
+//         langLoaded = true;
+//         window.lang = new lang(req.response as LangFile); 
+//     }
+// });
 
 window.animationEvent = whichAnimationEvent();
 
@@ -110,12 +121,12 @@ function login(username: string, password: string, run?: (state?: number) => voi
     req.onreadystatechange = function (): void {
         if (this.readyState == 4) {
             if (this.status != 200) {
-                let errorMsg = "Connection error.";
+                let errorMsg = window.lang.notif("errorConnection");
                 if (this.response) {
                     errorMsg = this.response["error"];
                 }
                 if (!errorMsg) {
-                    errorMsg = "Unknown error";
+                    errorMsg = window.lang.notif("errorUnknown");
                 }
                 if (!refresh) {
                     window.notifications.customError("loginError", errorMsg);
@@ -153,7 +164,7 @@ function login(username: string, password: string, run?: (state?: number) => voi
     const username = (document.getElementById("login-user") as HTMLInputElement).value;
     const password = (document.getElementById("login-password") as HTMLInputElement).value;
     if (!username || !password) {
-        window.notifications.customError("loginError", "The username and/or password were left blank.");
+        window.notifications.customError("loginError", window.lang.notif("errorLoginBlank"));
         return;
     }
     toggleLoader(button);

--- a/ts/admin.ts
+++ b/ts/admin.ts
@@ -1,5 +1,5 @@
 import { toggleTheme, loadTheme } from "./modules/theme.js";
-import { lang, LangFile } from "./modules/lang.js";
+import { lang, LangFile, loadLangSelector } from "./modules/lang.js";
 import { Modal } from "./modules/modal.js";
 import { Tabs } from "./modules/tabs.js";
 import { inviteList, createInvite } from "./modules/invites.js";
@@ -11,9 +11,8 @@ import { _get, _post, notificationBox, whichAnimationEvent, toggleLoader } from 
 loadTheme();
 (document.getElementById('button-theme') as HTMLSpanElement).onclick = toggleTheme;
 
-var langLoaded = false;
-
 window.lang = new lang(window.langFile as LangFile);
+loadLangSelector("admin");
 // _get(`/lang/admin/${window.language}.json`, null, (req: XMLHttpRequest) => {
 //     if (req.readyState == 4 && req.status == 200) {
 //         langLoaded = true;

--- a/ts/form.ts
+++ b/ts/form.ts
@@ -1,5 +1,6 @@
 import { Modal } from "./modules/modal.js";
 import { _get, _post, toggleLoader } from "./modules/common.js";
+import { loadLangSelector } from "./modules/lang.js";
 
 interface formWindow extends Window {
     validationStrings: pwValStrings;
@@ -21,23 +22,7 @@ interface pwValStrings {
     [ type: string ]: pwValString;
 }
 
-_get("/lang", null, (req: XMLHttpRequest) => {
-    if (req.readyState == 4) {
-        if (req.status != 200) {
-            document.getElementById("lang-dropdown").remove();
-            return;
-        }
-        const list = document.getElementById("lang-list") as HTMLDivElement;
-        let innerHTML = '';
-        for (let code in req.response) {
-            innerHTML += `<a href="?lang=${code}" class="button input ~neutral field mb-half">${req.response[code]}</a>`;
-        }
-        list.innerHTML = innerHTML;
-    }
-});
-
-
-
+loadLangSelector("form");
 
 window.modal = new Modal(document.getElementById("modal-success"));
 declare var window: formWindow;

--- a/ts/modules/accounts.ts
+++ b/ts/modules/accounts.ts
@@ -100,10 +100,10 @@ class user implements User {
         _post("/users/emails", send, (req: XMLHttpRequest) => {
             if (req.readyState == 4) {
                 if (req.status == 200) {
-                    window.notifications.customPositive("emailChanged", "Success:", `Changed email address of "${this.name}".`);
+                    window.notifications.customSuccess("emailChanged", window.lang.var("notifications", "changedEmailAddress", `"${this.name}"`));
                 } else {
                     this.email = oldEmail;
-                    window.notifications.customError("emailChanged", `Couldn't change email address of "${this.name}".`); 
+                    window.notifications.customError("emailChanged", window.lang.var("notifications", "errorChangedEmailAddress", `"${this.name}"`)); 
                 }
             }
         });
@@ -184,11 +184,9 @@ export class accountsList {
             }
             this._modifySettings.classList.remove("unfocused");
             this._deleteUser.classList.remove("unfocused");
-            (this._checkCount == 1) ? this._deleteUser.textContent = "Delete User" : this._deleteUser.textContent = "Delete Users";
+            this._deleteUser.textContent = window.lang.quantity("deleteUser", this._checkCount);
         }
     }
-
-    private _genCountString = (): string => { return `${this._checkCount} user${(this._checkCount > 1) ? "s" : ""}`; }
     
     private _collectUsers = (): string[] => {
         let list: string[] = [];
@@ -208,7 +206,7 @@ export class accountsList {
         };
         for (let field in send) {
             if (!send[field]) {
-                window.notifications.customError("addUserBlankField", "Fields were left blank.");
+                window.notifications.customError("addUserBlankField", window.lang.notif("errorBlankFields"));
                 return;
             }
         }
@@ -217,7 +215,7 @@ export class accountsList {
             if (req.readyState == 4) {
                 toggleLoader(button);
                 if (req.status == 200) {
-                    window.notifications.customPositive("addUser", "Success:", `user "${send['username']}" created.`);
+                    window.notifications.customSuccess("addUser", window.lang.var("notifications", "userCreated", `"${send['username']}"`));
                 }
                 this.reload();
                 window.modals.addUser.close();
@@ -227,7 +225,7 @@ export class accountsList {
 
     deleteUsers = () => {
         const modalHeader = document.getElementById("header-delete-user");
-        modalHeader.textContent = this._genCountString();
+        modalHeader.textContent = window.lang.quantity("deleteNUsers", this._checkCount);
         let list = this._collectUsers();
         const form = document.getElementById("form-delete-user") as HTMLFormElement;
         const button = form.querySelector("span.submit") as HTMLSpanElement;
@@ -247,13 +245,13 @@ export class accountsList {
                     toggleLoader(button);
                     window.modals.deleteUser.close();
                     if (req.status != 200 && req.status != 204) {
-                        let errorMsg = "Failed (check console/logs).";
+                        let errorMsg = window.lang.notif("errorFailureCheckLogs");
                         if (!("error" in req.response)) {
-                            errorMsg = "Partial failure (check console/logs).";
+                            errorMsg = window.lang.notif("errorPartialFailureCheckLogs");
                         }
                         window.notifications.customError("deleteUserError", errorMsg);
                     } else {
-                        window.notifications.customPositive("deleteUserSuccess", "Success:", `deleted ${this._genCountString()}.`);
+                        window.notifications.customSuccess("deleteUserSuccess", window.lang.quantity("deletedUser", this._checkCount));
                     }
                     this.reload();
                 }
@@ -264,7 +262,7 @@ export class accountsList {
 
     modifyUsers = () => {
         const modalHeader = document.getElementById("header-modify-user");
-        modalHeader.textContent = this._genCountString();
+        modalHeader.textContent = window.lang.quantity("modifySettingsFor", this._checkCount)
         let list = this._collectUsers();
         (() => {
             let innerHTML = "";
@@ -310,18 +308,18 @@ export class accountsList {
                             const homescreen = Object.keys(response["homescreen"]).length;
                             const policy = Object.keys(response["policy"]).length;
                             if (homescreen != 0 && policy == 0) {
-                                errorMsg = "Settings were applied, but applying homescreen layout may have failed.";
+                                errorMsg = window.lang.notif("errorSettingsAppliedNoHomescreenLayout");
                             } else if (policy != 0 && homescreen == 0) {
-                                errorMsg = "Homescreen layout was applied, but applying settings may have failed.";
+                                errorMsg = window.lang.notif("errorHomescreenAppliedNoSettings");
                             } else if (policy != 0 && homescreen != 0) {
-                                errorMsg = "Application failed.";
+                                errorMsg = window.lang.notif("errorSettingsFailed");
                             }
                         } else if ("error" in response) {
                             errorMsg = response["error"];
                         }
                         window.notifications.customError("modifySettingsError", errorMsg);
                     } else if (req.status == 200 || req.status == 204) {
-                        window.notifications.customPositive("modifySettingsSuccess", "Success:", `applied settings to ${this._genCountString()}.`);
+                        window.notifications.customSuccess("modifySettingsSuccess", window.lang.quantity("appliedSettings", this._checkCount));
                     }
                     this.reload();
                     window.modals.modifyUser.close();
@@ -330,8 +328,6 @@ export class accountsList {
         };
         window.modals.modifyUser.show();
     }
-
-
 
     constructor() {
         this._users = {};

--- a/ts/modules/common.ts
+++ b/ts/modules/common.ts
@@ -60,7 +60,7 @@ export const _get = (url: string, data: Object, onreadystatechange: (req: XMLHtt
             window.notifications.connectionError();
             return;
         } else if (req.status == 401) {
-            window.notifications.customError("401Error", "Unauthorized. Try logging back in.");
+            window.notifications.customError("401Error", window.lang.notif("error401Unauthorized"));
         }
         onreadystatechange(req);
     };
@@ -80,7 +80,7 @@ export const _post = (url: string, data: Object, onreadystatechange: (req: XMLHt
             window.notifications.connectionError();
             return;
         } else if (req.status == 401) {
-            window.notifications.customError("401Error", "Unauthorized. Try logging back in.");
+            window.notifications.customError("401Error", window.lang.notif("error401Unauthorized"));
         }
         onreadystatechange(req);
     };
@@ -97,7 +97,7 @@ export function _delete(url: string, data: Object, onreadystatechange: (req: XML
             window.notifications.connectionError();
             return;
         } else if (req.status == 401) {
-            window.notifications.customError("401Error", "Unauthorized. Try logging back in.");
+            window.notifications.customError("401Error", window.lang.notif("error401Unauthorized"));
         }
         onreadystatechange(req);
     };
@@ -131,7 +131,7 @@ export class notificationBox implements NotificationBox {
     private _error = (message: string): HTMLElement => {
         const noti = document.createElement('aside');
         noti.classList.add("aside", "~critical", "!normal", "mt-half", "notification-error");
-        noti.innerHTML = `<strong>Error:</strong> ${message}`;
+        noti.innerHTML = `<strong>${window.lang.strings("error")}:</strong> ${message}`;
         const closeButton = document.createElement('span') as HTMLSpanElement;
         closeButton.classList.add("button", "~critical", "!low", "ml-1");
         closeButton.innerHTML = `<i class="icon ri-close-line"></i>`;
@@ -152,7 +152,7 @@ export class notificationBox implements NotificationBox {
         return noti;
     }
     
-    connectionError = () => { this.customError("connectionError", "Couldn't connect to jfa-go."); }
+    connectionError = () => { this.customError("connectionError", window.lang.notif("errorConnection")); }
 
     customError = (type: string, message: string) => {
         this._errorTypes[type] = this._errorTypes[type] || false;
@@ -179,6 +179,8 @@ export class notificationBox implements NotificationBox {
         this._positiveTypes[type] = true;
         setTimeout(() => { if (this._box.contains(noti)) { this._box.removeChild(noti); this._positiveTypes[type] = false; } }, this.timeout*1000);
     }
+
+    customSuccess = (type: string, message: string) => this.customPositive(type, window.lang.strings("success") + ":", message)
 }
 
 export const whichAnimationEvent = () => {

--- a/ts/modules/invites.ts
+++ b/ts/modules/invites.ts
@@ -92,7 +92,7 @@ export class DOMInvite implements Invite {
         this._usedBy = uB;
         if (uB.length == 0) {
             this._right.classList.add("empty");
-            this._userTable.innerHTML = `<p class="content">None yet!</p>`;
+            this._userTable.innerHTML = `<p class="content">${window.lang.strings("inviteNoUsersCreated")}</p>`;
             return;
         }
         this._right.classList.remove("empty");
@@ -100,8 +100,8 @@ export class DOMInvite implements Invite {
         <table class="table inv-table">
             <thead>
                 <tr>
-                    <th>Name</th>
-                    <th>Date</th>
+                    <th>${window.lang.strings("name")}</th>
+                    <th>${window.lang.strings("date")}</th>
                 </tr>
             </thead>
             <tbody>
@@ -153,7 +153,7 @@ export class DOMInvite implements Invite {
         } else {
             selected = selected || select.value;
         }
-        let innerHTML = `<option value="noProfile" ${noProfile ? "selected" : ""}>No Profile</option>`;
+        let innerHTML = `<option value="noProfile" ${noProfile ? "selected" : ""}>${window.lang.strings("inviteNoProfile")}</option>`;
         for (let profile of window.availableProfiles) {
             innerHTML += `<option value="${profile}" ${((profile == selected) && !noProfile) ? "selected" : ""}>${profile}</option>`;
         }
@@ -221,7 +221,7 @@ export class DOMInvite implements Invite {
         this._codeArea.classList.add("inv-codearea");
         this._codeArea.innerHTML = `
         <a class="invite-link code monospace mr-1" href=""></a>
-        <span class="button ~info !normal" title="Copy invite link"><i class="ri-file-copy-line"></i></span>
+        <span class="button ~info !normal" title="${window.lang.strings("copy")}"><i class="ri-file-copy-line"></i></span>
         `;
         const copyButton = this._codeArea.querySelector("span.button") as HTMLSpanElement;
         copyButton.onclick = () => { 
@@ -248,7 +248,7 @@ export class DOMInvite implements Invite {
             <span class="content sm"></span>
         </div>
         <span class="inv-expiry mr-1"></span>
-        <span class="button ~critical !normal inv-delete">Delete</span>
+        <span class="button ~critical !normal inv-delete">${window.lang.strings("delete")}</span>
         <label>
             <i class="icon clickable ri-arrow-down-s-line not-rotated"></i>
             <input class="inv-toggle-details unfocused" type="checkbox">
@@ -271,23 +271,23 @@ export class DOMInvite implements Invite {
         detailsInner.appendChild(this._left);
         this._left.classList.add("inv-profilearea");
         let innerHTML = `
-        <p class="supra mb-1 top">Profile</p>
+        <p class="supra mb-1 top">${window.lang.strings("profile")}</p>
         <div class="select ~neutral !normal inv-profileselect inline-block">
             <select>
-                <option value="noProfile" selected>No Profile</option>
+                <option value="noProfile" selected>${window.lang.strings("inviteNoProfile")}</option>
             </select>
         </div>
         `;
         if (window.notificationsEnabled) {
             innerHTML += `
-            <p class="label supra">Notify on:</p>
+            <p class="label supra">${window.lang.strings("notifyEvent")}</p>
             <label class="switch block">
                 <input class="inv-notify-expiry" type="checkbox">
-                <span>On expiry</span>
+                <span>${window.lang.strings("notifyInviteExpiry")}</span>
             </label>
             <label class="switch block">
                 <input class="inv-notify-creation" type="checkbox">
-                <span>On user creation</span>
+                <span>${window.lang.strings("notifyUserCreation")}</span>
             </label>
             `;
         }
@@ -306,14 +306,14 @@ export class DOMInvite implements Invite {
         detailsInner.appendChild(this._middle);
         this._middle.classList.add("block");
         this._middle.innerHTML = `
-        <p class="supra mb-1 top">Created <strong class="inv-created"></strong></p>
-        <p class="supra mb-1">Remaining uses <strong class="inv-remaining"></strong></p>
+        <p class="supra mb-1 top">${window.lang.strings("inviteDateCreated")} <strong class="inv-created"></strong></p>
+        <p class="supra mb-1">${window.lang.strings("inviteRemainingUses")} <strong class="inv-remaining"></strong></p>
         `;
 
         this._right = document.createElement('div') as HTMLDivElement;
         detailsInner.appendChild(this._right);
         this._right.classList.add("card", "~neutral", "!low", "inv-created-users");
-        this._right.innerHTML = `<strong class="supra table-header">Created users</strong>`;
+        this._right.innerHTML = `<strong class="supra table-header">${window.lang.strings("inviteUsersCreated")}</strong>`;
         this._userTable = document.createElement('div') as HTMLDivElement;
         this._right.appendChild(this._userTable);
 
@@ -376,7 +376,7 @@ export class inviteList implements inviteList {
             <div class="inv inv-empty">
                 <div class="card ~neutral !normal inv-header flex-expand mt-half">
                     <div class="inv-codearea">
-                        <span class="code monospace">None</span>
+                        <span class="code monospace">${window.lang.strings("inviteNoInvites")}</span>
                     </div>
                 </div>
             </div>
@@ -441,10 +441,10 @@ function parseInvite(invite: { [f: string]: string | number | string[][] | boole
             time += `${invite[fields[i]]}${fields[i][0]} `;
         }
     }
-    parsed.expiresIn = `Expires in ${time.slice(0, -1)}`;
+    parsed.expiresIn = window.lang.var("strings", "inviteExpiresInTime", time.slice(0, -1));
     parsed.remainingUses = invite["no-limit"] ? "∞" : String(invite["remaining-uses"])
     parsed.usedBy = invite["used-by"] as string[][] || [];
-    parsed.created = invite["created"] as string || "Unknown";
+    parsed.created = invite["created"] as string || window.lang.strings("unknown");
     parsed.profile = invite["profile"] as string || "";
     parsed.notifyExpiry = invite["notify-expiry"] as boolean || false;
     parsed.notifyCreation = invite["notify-creation"] as boolean || false;
@@ -566,7 +566,7 @@ export class createInvite {
     }
 
     loadProfiles = () => {
-        let innerHTML = `<option value="noProfile">No Profile</option>`;
+        let innerHTML = `<option value="noProfile">${window.lang.strings("inviteNoProfile")}</option>`;
         for (let profile of window.availableProfiles) {
             innerHTML += `<option value="${profile}">${profile}</option>`;
         }

--- a/ts/modules/lang.ts
+++ b/ts/modules/lang.ts
@@ -1,0 +1,52 @@
+interface Meta {
+    name: string;
+}
+
+interface quantityString {
+    singular: string;
+    plural: string;
+}
+
+export interface LangFile {
+    meta: Meta;
+    strings: { [key: string]: string };
+    notifications: { [key: string]: string };
+    quantityStrings: { [key: string]: quantityString };
+}
+
+export class lang implements Lang {
+    private _lang: LangFile;
+    constructor(lang: LangFile) {
+        this._lang = lang;
+    }
+
+    get = (sect: string, key: string): string => {
+        if (sect == "quantityStrings" || sect == "meta") { return ""; }
+        return this._lang[sect][key];
+    }
+
+    strings = (key: string): string => this.get("strings", key)
+    notif = (key: string): string => this.get("notifications", key)
+
+    var = (sect: string, key: string, ...subs: string[]): string => {
+        if (sect == "quantityStrings" || sect == "meta") { return ""; }
+        let str = this._lang[sect][key];
+        for (let sub of subs) {
+            str = str.replace("{n}", sub);
+        }
+        return str;
+    }
+
+    quantity = (key: string, number: number): string => {
+        if (number == 1) {
+            return this._lang.quantityStrings[key].singular.replace("{n}", ""+number)
+        }
+        return this._lang.quantityStrings[key].plural.replace("{n}", ""+number);
+    }
+}
+
+
+
+
+
+

--- a/ts/modules/lang.ts
+++ b/ts/modules/lang.ts
@@ -1,3 +1,5 @@
+import { _get } from "../modules/common.js";
+
 interface Meta {
     name: string;
 }
@@ -45,7 +47,20 @@ export class lang implements Lang {
     }
 }
 
-
+export const loadLangSelector = (page: string) => _get("/lang/" + page, null, (req: XMLHttpRequest) => {
+    if (req.readyState == 4) {
+        if (req.status != 200) {
+            document.getElementById("lang-dropdown").remove();
+            return;
+        }
+        const list = document.getElementById("lang-list") as HTMLDivElement;
+        let innerHTML = '';
+        for (let code in req.response) {
+            innerHTML += `<a href="?lang=${code}" class="button input ~neutral field mb-half">${req.response[code]}</a>`;
+        }
+        list.innerHTML = innerHTML;
+    }
+});
 
 
 

--- a/ts/modules/profiles.ts
+++ b/ts/modules/profiles.ts
@@ -44,7 +44,7 @@ class profile implements Profile {
             <td><input type="radio" name="profile-default"></td>
             <td class="profile-from ellipsis"></td>
             <td class="profile-libraries"></td>
-            <td><span class="button ~critical !normal">Delete</span></td>
+            <td><span class="button ~critical !normal">${window.lang.strings("delete")}</span></td>
         `;
         this._name = this._row.querySelector("b.profile-name");
         this._adminChip = this._row.querySelector("span.profile-admin") as HTMLSpanElement;
@@ -71,7 +71,7 @@ class profile implements Profile {
             if (req.status == 200 || req.status == 204) {
                 this.remove();
             } else {
-                window.notifications.customError("profileDelete", `Failed to delete profile "${this.name}"`);
+                window.notifications.customError("profileDelete", window.lang.var("notifications", "errorDeleteProfile", `"${this.name}"`));
             }
         }
     })
@@ -98,7 +98,7 @@ export class ProfileEditor {
     get empty(): boolean { return (Object.keys(this._table.children).length == 0) }
     set empty(state: boolean) {
         if (state) {
-            this._table.innerHTML = `<tr><td class="empty">None</td></tr>`
+            this._table.innerHTML = `<tr><td class="empty">${window.lang.strings("inviteNoInvites")}</td></tr>`
         } else if (this._table.querySelector("td.empty")) {
             this._table.textContent = ``;
         }
@@ -133,7 +133,7 @@ export class ProfileEditor {
                 this.default = resp.default_profile;
                 window.modals.profiles.show();
             } else {
-                window.notifications.customError("profileEditor", "Failed to load profiles.");
+                window.notifications.customError("profileEditor", window.lang.notif("errorLoadProfiles"));
             }
         }
     })
@@ -149,7 +149,7 @@ export class ProfileEditor {
                         this.default = newDefault;
                     } else {
                         this.default = prevDefault;
-                        window.notifications.customError("profileDefault", "Failed to set default profile.");
+                        window.notifications.customError("profileDefault", window.lang.notif("errorSetDefaultProfile"));
                     }
                 }
             });
@@ -171,7 +171,7 @@ export class ProfileEditor {
                     window.modals.profiles.close();
                     window.modals.addProfile.show();
                 } else {
-                    window.notifications.customError("loadUsers", "Failed to load users.");
+                    window.notifications.customError("loadUsers", window.lang.notif("errorLoadUsers"));
                 }
             }
         });
@@ -191,9 +191,9 @@ export class ProfileEditor {
                     window.modals.addProfile.close();
                     if (req.status == 200 || req.status == 204) {
                         this.load();
-                        window.notifications.customPositive("createProfile", "Success:", `created profile "${send['name']}"`);
+                        window.notifications.customSuccess("createProfile", window.lang.var("notifications", "createProfile", `"${send['name']}"`));
                     } else {
-                        window.notifications.customError("createProfile", `Failed to create profile "${send['name']}"`);
+                        window.notifications.customError("createProfile", window.lang.var("notifications", "errorCreateProfile", `"${send['name']}"`));
                     }
                     window.modals.profiles.show();
                 }

--- a/ts/modules/settings.ts
+++ b/ts/modules/settings.ts
@@ -345,6 +345,17 @@ class DOMSelect implements SSelect {
             if (this.requires_restart) { document.dispatchEvent(new CustomEvent("settings-requires-restart")); }
         };
         this._select.onchange = onValueChange;
+
+        const message = document.getElementById("settings-message") as HTMLElement;
+        message.innerHTML = window.lang.var("strings",
+                                            "settingsRequiredOrRestartMessage",
+                                            `<span class="badge ~critical">*</span>`,
+                                            `<span class="badge ~info">R</span>`
+        );
+
+
+                                            
+
         this.update(setting);
     }
     update = (s: SSelect) => {
@@ -501,9 +512,9 @@ export class settingsList {
     private _send = (config: Object, run?: () => void) => _post("/config", config, (req: XMLHttpRequest) => {
         if (req.readyState == 4) {
             if (req.status == 200 || req.status == 204) {
-                window.notifications.customPositive("settingsSaved", "Success:", "settings were saved.");
+                window.notifications.customSuccess("settingsSaved", window.lang.notif("saveSettings"));
             } else {
-                window.notifications.customError("settingsSaved", "Couldn't save settings.");
+                window.notifications.customError("settingsSaved", window.lang.notif("errorSaveSettings"));
             }
             this.reload();
             if (run) { run(); }
@@ -526,7 +537,7 @@ export class settingsList {
     reload = () => _get("/config", null, (req: XMLHttpRequest) => {
         if (req.readyState == 4) {
             if (req.status != 200) {
-                window.notifications.customError("settingsLoadError", "Failed to load settings.");
+                window.notifications.customError("settingsLoadError", window.lang.notif("errorLoadSettings"));
                 return;
             }
             let settings = req.response as Settings;
@@ -558,7 +569,7 @@ class ombiDefaults {
     constructor() {
         this._button = document.createElement("span") as HTMLSpanElement;
         this._button.classList.add("button", "~neutral", "!low", "settings-section-button", "mb-half");
-        this._button.innerHTML = `<span class="flex">Ombi user defaults <i class="ri-link-unlink-m ml-half"></i></span>`;
+        this._button.innerHTML = `<span class="flex">${window.lang.strings("ombiUserDefaults")} <i class="ri-link-unlink-m ml-half"></i></span>`;
         this._button.onclick = this.load;
         this._form = document.getElementById("form-ombi-defaults") as HTMLFormElement;
         this._form.onsubmit = this.send;
@@ -575,9 +586,9 @@ class ombiDefaults {
             if (req.readyState == 4) {
                 toggleLoader(button);
                 if (req.status == 200 || req.status == 204) {
-                    window.notifications.customPositive("ombiDefaults", "Success:", "stored ombi defaults.");
+                    window.notifications.customSuccess("ombiDefaults", window.lang.notif("setOmbiDefaults"));
                 } else {
-                    window.notifications.customError("ombiDefaults", "Failed to store ombi defaults.");
+                    window.notifications.customError("ombiDefaults", window.lang.notif("errorSetOmbiDefaults"));
                 }
                 window.modals.ombiDefaults.close();
             }
@@ -600,15 +611,9 @@ class ombiDefaults {
                     window.modals.ombiDefaults.show();
                 } else {
                     toggleLoader(this._button);
-                    window.notifications.customError("ombiLoadError", "Failed to load ombi users.")
+                    window.notifications.customError("ombiLoadError", window.lang.notif("errorLoadOmbiUsers"))
                 }
             }
         });
     }
 }
-
-
-
-
-
-

--- a/ts/typings/d.ts
+++ b/ts/typings/d.ts
@@ -27,12 +27,24 @@ declare interface Window {
     tabs: Tabs;
     invites: inviteList;
     notifications: NotificationBox;
+    language: string;
+    lang: Lang;
+    langFile: {};
+}
+
+declare interface Lang {
+    get: (sect: string, key: string) => string;
+    strings: (key: string) => string;
+    notif: (key: string) => string;
+    var: (sect: string, key: string, ...subs: string[]) => string;
+    quantity: (key: string, number: number) => string;
 }
 
 declare interface NotificationBox {
     connectionError: () => void;
     customError: (type: string, message: string) => void;
     customPositive: (type: string, bold: string,  message: string) => void;
+    customSuccess: (type: string, message: string) => void;
 }
 
 declare interface Tabs {

--- a/views.go
+++ b/views.go
@@ -34,6 +34,7 @@ func (app *appContext) AdminPage(gc *gin.Context) {
 		"username":        !app.config.Section("email").Key("no_username").MustBool(false),
 		"strings":         app.storage.lang.Admin[lang]["strings"],
 		"quantityStrings": app.storage.lang.Admin[lang]["quantityStrings"],
+		"language":        app.storage.lang.AdminJSON[lang],
 	})
 }
 

--- a/views.go
+++ b/views.go
@@ -13,19 +13,27 @@ func gcHTML(gc *gin.Context, code int, file string, templ gin.H) {
 }
 
 func (app *appContext) AdminPage(gc *gin.Context) {
+	lang := gc.Query("lang")
+	if lang == "" {
+		lang = app.storage.lang.chosenFormLang
+	} else if _, ok := app.storage.lang.Form[lang]; !ok {
+		lang = app.storage.lang.chosenFormLang
+	}
 	emailEnabled, _ := app.config.Section("invite_emails").Key("enabled").Bool()
 	notificationsEnabled, _ := app.config.Section("notifications").Key("enabled").Bool()
 	ombiEnabled := app.config.Section("ombi").Key("enabled").MustBool(false)
 	gcHTML(gc, http.StatusOK, "admin.html", gin.H{
-		"urlBase":        app.URLBase,
-		"cssClass":       app.cssClass,
-		"contactMessage": "",
-		"email_enabled":  emailEnabled,
-		"notifications":  notificationsEnabled,
-		"version":        VERSION,
-		"commit":         COMMIT,
-		"ombiEnabled":    ombiEnabled,
-		"username":       !app.config.Section("email").Key("no_username").MustBool(false),
+		"urlBase":         app.URLBase,
+		"cssClass":        app.cssClass,
+		"contactMessage":  "",
+		"email_enabled":   emailEnabled,
+		"notifications":   notificationsEnabled,
+		"version":         VERSION,
+		"commit":          COMMIT,
+		"ombiEnabled":     ombiEnabled,
+		"username":        !app.config.Section("email").Key("no_username").MustBool(false),
+		"strings":         app.storage.lang.Admin[lang]["strings"],
+		"quantityStrings": app.storage.lang.Admin[lang]["quantityStrings"],
 	})
 }
 

--- a/views.go
+++ b/views.go
@@ -22,6 +22,14 @@ func (app *appContext) AdminPage(gc *gin.Context) {
 	emailEnabled, _ := app.config.Section("invite_emails").Key("enabled").Bool()
 	notificationsEnabled, _ := app.config.Section("notifications").Key("enabled").Bool()
 	ombiEnabled := app.config.Section("ombi").Key("enabled").MustBool(false)
+	if pusher := gc.Writer.Pusher(); pusher != nil {
+		toPush := []string{"/js/admin.js", "/js/theme.js", "/js/lang.js", "/js/modal.js", "/js/tabs.js", "/js/invites.js", "/js/accounts.js", "/js/settings.js", "/js/profiles.js", "/js/common.js"}
+		for _, f := range toPush {
+			if err := pusher.Push(f, nil); err != nil {
+				app.debug.Printf("Failed HTTP2 ServerPush of \"%s\": %+v", f, err)
+			}
+		}
+	}
 	gcHTML(gc, http.StatusOK, "admin.html", gin.H{
 		"urlBase":         app.URLBase,
 		"cssClass":        app.cssClass,

--- a/views.go
+++ b/views.go
@@ -15,9 +15,9 @@ func gcHTML(gc *gin.Context, code int, file string, templ gin.H) {
 func (app *appContext) AdminPage(gc *gin.Context) {
 	lang := gc.Query("lang")
 	if lang == "" {
-		lang = app.storage.lang.chosenFormLang
+		lang = app.storage.lang.chosenAdminLang
 	} else if _, ok := app.storage.lang.Form[lang]; !ok {
-		lang = app.storage.lang.chosenFormLang
+		lang = app.storage.lang.chosenAdminLang
 	}
 	emailEnabled, _ := app.config.Section("invite_emails").Key("enabled").Bool()
 	notificationsEnabled, _ := app.config.Section("notifications").Key("enabled").Bool()


### PR DESCRIPTION
Add the ability to translate the admin page and all emails, as well as a french translation of both thanks to @Killianbe and @Cornichon420. Also includes a fix to show the username input to "Add user" in the accounts tab, and an attempt to use http2 server push for admin resources which may or may not work.