### PR TITLE
use `apt-get` instead of `apt`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM --platform=$BUILDPLATFORM golang:latest AS support
 
 COPY . /opt/build
 
-RUN apt update -y \
-    && apt install build-essential python3-pip curl software-properties-common sed -y \
+RUN apt-get update -y \
+    && apt-get install build-essential python3-pip curl software-properties-common sed -y \
     && (curl -sL https://deb.nodesource.com/setup_14.x | bash -) \
-    && apt install nodejs \
+    && apt-get install nodejs \
     && (cd /opt/build; make configuration npm email version typescript bundle-css swagger copy external-files GOESBUILD=on) \
     && sed -i 's#id="password_resets-watch_directory" placeholder="/config/jellyfin"#id="password_resets-watch_directory" value="/jf" disabled#g' /opt/build/build/data/html/setup.html
 


### PR DESCRIPTION
Because `apt` is meant for humans, and complains when called in scripts.
(manpage: "While it tries not to break backward compatibility this is not guaranteed")