### PR TITLE
Add checkbox that allows invalid SMTP certificates to be used.

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,6 +72,7 @@ func (app *appContext) loadConfig() error {
 	app.MustSetValue("deletion", "email_text", "jfa-go:"+"deleted.txt")
 
 	app.MustSetValue("smtp", "hello_hostname", "localhost")
+	app.MustSetValue("smtp", "cert_validation", "true")
 
 	jfUrl := app.config.Section("jellyfin").Key("server").String()
 	if !(strings.HasPrefix(jfUrl, "http://") || strings.HasPrefix(jfUrl, "https://")) {

--- a/config/config-base.json
+++ b/config/config-base.json
@@ -552,6 +552,15 @@
                     "type": "text",
                     "value": "",
                     "description": "Use if your SMTP server's SSL Certificate is not trusted by the system."
+                },
+                "cert_validation": {
+                    "name": "Verify certificate",
+                    "required": false,
+                    "requires_restart": false,
+                    "advanced": true,
+                    "type": "bool",
+                    "value": true,
+                    "description": "Warning, disabling this makes you much more vulnerable to man-in-the-middle attacks"
                 }
             }
         },

--- a/email.go
+++ b/email.go
@@ -84,7 +84,7 @@ func NewEmailer(app *appContext) *Emailer {
 		if username == "" && password != "" {
 			username = emailer.fromAddr
 		}
-		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String())
+		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String(), app.config.Section("smtp").Key("cert-validation").MustBool(true))
 		if err != nil {
 			app.err.Printf("Error while initiating SMTP mailer: %v", err)
 		}
@@ -110,7 +110,7 @@ type SMTP struct {
 }
 
 // NewSMTP returns an SMTP emailClient.
-func (emailer *Emailer) NewSMTP(server string, port int, username, password string, sslTLS bool, certPath string, helloHostname string) (err error) {
+func (emailer *Emailer) NewSMTP(server string, port int, username, password string, sslTLS bool, certPath string, helloHostname string, validateCertificate bool) (err error) {
 	sender := &SMTP{}
 	sender.Client = sMail.NewSMTPClient()
 	if sslTLS {
@@ -131,7 +131,7 @@ func (emailer *Emailer) NewSMTP(server string, port int, username, password stri
 	// x509.SystemCertPool is unavailable on windows
 	if PLATFORM == "windows" {
 		sender.Client.TLSConfig = &tls.Config{
-			InsecureSkipVerify: false,
+			InsecureSkipVerify: validateCertificate,
 			ServerName:         server,
 		}
 		emailer.sender = sender
@@ -149,7 +149,7 @@ func (emailer *Emailer) NewSMTP(server string, port int, username, password stri
 		}
 	}
 	sender.Client.TLSConfig = &tls.Config{
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: validateCertificate,
 		ServerName:         server,
 		RootCAs:            rootCAs,
 	}

--- a/email.go
+++ b/email.go
@@ -84,7 +84,7 @@ func NewEmailer(app *appContext) *Emailer {
 		if username == "" && password != "" {
 			username = emailer.fromAddr
 		}
-		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String(), app.config.Section("smtp").Key("cert-validation").MustBool(true))
+		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String(), app.config.Section("smtp").Key("cert_validation").MustBool(true))
 		if err != nil {
 			app.err.Printf("Error while initiating SMTP mailer: %v", err)
 		}
@@ -131,7 +131,7 @@ func (emailer *Emailer) NewSMTP(server string, port int, username, password stri
 	// x509.SystemCertPool is unavailable on windows
 	if PLATFORM == "windows" {
 		sender.Client.TLSConfig = &tls.Config{
-			InsecureSkipVerify: validateCertificate,
+			InsecureSkipVerify: !validateCertificate,
 			ServerName:         server,
 		}
 		emailer.sender = sender
@@ -149,7 +149,7 @@ func (emailer *Emailer) NewSMTP(server string, port int, username, password stri
 		}
 	}
 	sender.Client.TLSConfig = &tls.Config{
-		InsecureSkipVerify: validateCertificate,
+		InsecureSkipVerify: !validateCertificate,
 		ServerName:         server,
 		RootCAs:            rootCAs,
 	}

--- a/ts/setup.ts
+++ b/ts/setup.ts
@@ -296,8 +296,7 @@ const settings = {
         "encryption": new Select(get("smtp-encryption")),
         "server": new Input(get("smtp-server")),
         "port": new Input(get("smtp-port")),
-        "password": new Input(get("smtp-password")),
-        "cert-validation": new Input(get("smtp-cert-validation"))
+        "password": new Input(get("smtp-password"))
     },
     "ombi": {
         "enabled": new Checkbox(get("ombi-enabled"), "", false, "ombi", "enabled"),

--- a/ts/setup.ts
+++ b/ts/setup.ts
@@ -296,7 +296,8 @@ const settings = {
         "encryption": new Select(get("smtp-encryption")),
         "server": new Input(get("smtp-server")),
         "port": new Input(get("smtp-port")),
-        "password": new Input(get("smtp-password"))
+        "password": new Input(get("smtp-password")),
+        "cert-validation": new Input(get("smtp-cert-validation"))
     },
     "ombi": {
         "enabled": new Checkbox(get("ombi-enabled"), "", false, "ombi", "enabled"),


### PR DESCRIPTION
I'm using a protonmail-bridge hosted in a docker container on a different machine in my network as mail server. Unfortunately the protonmail-bridge certificate is only signed for 127.0.0.1. 
I've tested these changes and they enable me to use my protonmail bridge as a mailserver.
I tried to make the checkbox seem a bit more dangerous to use but this is my first time using any of the languages and techniques used in this project and couldn't quite figure it out.