### PR TITLE
Cursor pointer UX consistency

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -556,3 +556,7 @@ div.card:contains(section.banner.footer) {
 .text-center-i {
     text-align: center !important;
 }
+
+input[type="checkbox" i], [class^="ri-"], [class*=" ri-"], .ri-refresh-line:before {
+    cursor: pointer;
+}

--- a/css/base.css
+++ b/css/base.css
@@ -557,6 +557,6 @@ div.card:contains(section.banner.footer) {
     text-align: center !important;
 }
 
-input[type="checkbox" i], [class^="ri-"], [class*=" ri-"], .ri-refresh-line:before {
+input[type="checkbox" i], [class^="ri-"], [class*=" ri-"], .ri-refresh-line:before, .modal-close {
     cursor: pointer;
 }


### PR DESCRIPTION
Personal preference but I have noticed some selectable elements currently are set to `cursor: default`. I have changed the following to `cursor: pointer`.

- checkbox's on the accounts and settings page
- edit email button on accounts page
- invite page, captcha refresh button
- modal close