### PR TITLE
fixed setExpiry() and added checked to admin only 

### DIFF
--- a/html/setup.html
+++ b/html/setup.html
@@ -137,7 +137,7 @@
                         <input type="radio" class="mr-2" name="ui-jellyfin_login" value="true" checked><span>{{ .lang.Login.authorizeWithJellyfin }}</span>
                     </label>
                     <label class="row switch pl-4 pb-4">
-                        <input type="checkbox" class="mr-2" id="ui-admin_only"><span>{{ .lang.Login.adminOnly }}</span>
+                        <input type="checkbox" class="mr-2" id="ui-admin_only" checked><span>{{ .lang.Login.adminOnly }}</span>
                     </label>
                     <label class="row switch pl-4 pb-2">
                         <input type="checkbox" class="mr-2" id="ui-allow_all"><span>{{ .lang.Login.allowAll }}</span>

--- a/ts/modules/accounts.ts
+++ b/ts/modules/accounts.ts
@@ -1334,9 +1334,7 @@ export class accountsList {
         const list = this._collectUsers();
         let applyList: string[] = [];
         for (let id of list) {
-            if (this._users[id].expiry || enableUser) {
-                applyList.push(id);
-            }
+            applyList.push(id);
         }
         this._enableExpiryReason.classList.add("unfocused");
         let header: string;


### PR DESCRIPTION
The bug was that setExpiry didn't work if account was enabled and didn't have an expiry already.