### PR TITLE
feat: Add SMTP authentication types to settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -76,6 +76,7 @@ func (app *appContext) loadConfig() error {
 
 	app.MustSetValue("smtp", "hello_hostname", "localhost")
 	app.MustSetValue("smtp", "cert_validation", "true")
+	app.MustSetValue("smtp", "auth_type", "4")
 
 	sc := app.config.Section("discord").Key("start_command").MustString("start")
 	app.config.Section("discord").Key("start_command").SetValue(strings.TrimPrefix(strings.TrimPrefix(sc, "/"), "!"))

--- a/config/config-base.json
+++ b/config/config-base.json
@@ -918,6 +918,22 @@
                     "type": "bool",
                     "value": true,
                     "description": "Warning, disabling this makes you much more vulnerable to man-in-the-middle attacks"
+                },
+                "auth_type": {
+                    "name": "Authentication type",
+                    "required": false,
+                    "requires_restart": false,
+                    "advanced": false,
+                    "type": "select",
+                    "options": [
+                        ["0", "Plain"],
+                        ["1", "Login"],
+                        ["2", "CRAM-MD5"],
+                        ["3", "None"],
+                        ["4", "Auto"]
+                    ],
+                    "value": 4,
+                    "description": "SMTP authentication method"
                 }
             }
         },

--- a/email.go
+++ b/email.go
@@ -92,7 +92,8 @@ func NewEmailer(app *appContext) *Emailer {
 		if app.proxyEnabled {
 			proxyConf = &app.proxyConfig
 		}
-		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String(), app.config.Section("smtp").Key("cert_validation").MustBool(true), proxyConf)
+		authType := sMail.AuthType(app.config.Section("smtp").Key("auth_type").MustInt(4))
+		err := emailer.NewSMTP(app.config.Section("smtp").Key("server").String(), app.config.Section("smtp").Key("port").MustInt(465), username, password, sslTLS, app.config.Section("smtp").Key("ssl_cert").MustString(""), app.config.Section("smtp").Key("hello_hostname").String(), app.config.Section("smtp").Key("cert_validation").MustBool(true), authType, proxyConf)
 		if err != nil {
 			app.err.Printf("Error while initiating SMTP mailer: %v", err)
 		}
@@ -118,7 +119,7 @@ type SMTP struct {
 }
 
 // NewSMTP returns an SMTP emailClient.
-func (emailer *Emailer) NewSMTP(server string, port int, username, password string, sslTLS bool, certPath string, helloHostname string, validateCertificate bool, proxy *easyproxy.ProxyConfig) (err error) {
+func (emailer *Emailer) NewSMTP(server string, port int, username, password string, sslTLS bool, certPath string, helloHostname string, validateCertificate bool, authType sMail.AuthType, proxy *easyproxy.ProxyConfig) (err error) {
 	sender := &SMTP{}
 	sender.Client = sMail.NewSMTPClient()
 	if sslTLS {
@@ -127,7 +128,7 @@ func (emailer *Emailer) NewSMTP(server string, port int, username, password stri
 		sender.Client.Encryption = sMail.EncryptionSTARTTLS
 	}
 	if username != "" || password != "" {
-		sender.Client.Authentication = sMail.AuthLogin
+		sender.Client.Authentication = authType
 		sender.Client.Username = username
 		sender.Client.Password = password
 	}


### PR DESCRIPTION
Didn't add it to the setup pages, but it should work fine for any SMTP server now that the default authentication option is set to auto, which _should_ select the best available option returned by the server.

Tested it on my own server and it seems to work, so now it's compatible with Protonmail's SMTP server :)
https://proton.me/support/smtp-submission