### PR TITLE
Fix referral url when subdomain contains `account`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -85,7 +85,7 @@ steps:
       commands:
         - curl -sL https://git.io/goreleaser > goreleaser
         - chmod +x goreleaser
-        - ./scripts/version.sh ./goreleaser --snapshot --skip-publish --clean
+        - ./scripts/version.sh ./goreleaser --snapshot --skip=publish --clean
         - wget https://builds.hrfee.pw/upload.py
         - pip3 install requests
         - bash -c 'sftp -i /id_rsa2 -o StrictHostKeyChecking=no root@161.97.102.153:/mnt/redoc <<< $"put docs/swagger.json jfa-go.json"'
@@ -164,7 +164,7 @@ steps:
       commands:
         - curl -sL https://git.io/goreleaser > goreleaser
         - chmod +x goreleaser
-        - ./scripts/version.sh ./goreleaser --snapshot --skip-publish --clean
+        - ./scripts/version.sh ./goreleaser --snapshot --skip=publish --clean
 
 trigger:
     event:

--- a/ts/user.ts
+++ b/ts/user.ts
@@ -266,12 +266,20 @@ class ReferralCard {
     get code(): string { return this._code; }
     set code(c: string) {
         this._code = c;
-        let url = window.location.href;
-        let pathArray = url.split('/');
-        url = `${pathArray[0]}//${pathArray[2]}/`;
-        if (url.slice(-1) != "/") { url += "/"; }
-        url = url + "invite/" + this._code;
-        this._url = url;
+        
+        let u = new URL(window.location.href);
+        let path = u.pathname;
+        for (let split of ["account", "my"]) {
+            path = path.split(split)[0];
+        }
+        if (path.slice(-1) != "/") { path += "/"; }
+        path = path + "invite/" + this._code;
+        
+        u.pathname = path;
+        u.hash = "";
+        u.search = "";
+    
+        this._url = u.toString();
     }
 
     get remaining_uses(): number { return this._remainingUses; }

--- a/ts/user.ts
+++ b/ts/user.ts
@@ -267,9 +267,8 @@ class ReferralCard {
     set code(c: string) {
         this._code = c;
         let url = window.location.href;
-        for (let split of ["#", "?", "account", "my"]) {
-            url = url.split(split)[0];
-        }
+        let pathArray = url.split('/');
+        url = `${pathArray[0]}//${pathArray[2]}/`;
         if (url.slice(-1) != "/") { url += "/"; }
         url = url + "invite/" + this._code;
         this._url = url;


### PR DESCRIPTION
This fix should work to grab the base url more consistently when the sub domain includes `account` in the name.

This fix is related to the issue I created here https://github.com/hrfee/jfa-go/issues/346