### PR TITLE
fix: added discord and telegram linking verification on sign up page

### DIFF
--- a/api-users.go
+++ b/api-users.go
@@ -337,11 +337,13 @@ func (app *appContext) PostNewUserFromInvite(nu NewUserData, req ConfirmationKey
 		// FIXME: figure these out in a nicer way? this relies on the current ordering,
 		// which may not be fixed.
 		if discordEnabled {
-			discordUser = req.completeContactMethods[0].User.(*DiscordUser)
-			if telegramEnabled {
+		    if req.completeContactMethods[0].User != nil {
+			    discordUser = req.completeContactMethods[0].User.(*DiscordUser)
+			}
+			if telegramEnabled && req.completeContactMethods[1].User != nil {
 				telegramUser = req.completeContactMethods[1].User.(*TelegramUser)
 			}
-		} else if telegramEnabled {
+		} else if telegramEnabled && req.completeContactMethods[0].User != nil {
 			telegramUser = req.completeContactMethods[0].User.(*TelegramUser)
 		}
 	}


### PR DESCRIPTION
This simple PR fixes the issue I encountered on issue #375. 

In `api-users.go`, the code block from line 336 to 347 didn't check if user has linked or not their Other contact methods before sending it to Jellyseerr or Ombi. `req.completeContactMethods[x].User` was trying to get casted even if it was a `nil` value, triggering a casting error by go.

A few tests should be made to ensure no errors about sign up page is present anymore:

- [x] Not linking any account
- [x] Linking Discord only
- [ ] Linking Telegram only
- [ ] Linking both Discord and Telegram