### PR TITLE
scripts: use more portable shebang

### DIFF
--- a/scripts/dark-variant.sh
+++ b/scripts/dark-variant.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # scan all typescript and automatically add dark variants to color tags if they're not already present.
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/env/bin bash
 # sets version environment variable for goreleaser to use
 # scripts/version.sh goreleaser ...
 


### PR DESCRIPTION
This updates the shebangs to use `env bash`, which will use Bash from the user's path. This is primarily helpful on distro's such as NixOS and GNU Guix that do not follow FHS, but keep the `env` binary in this location for compatibility.