### PR TITLE
jellyseerr: delete user on account deletion

### DIFF
--- a/users.go
+++ b/users.go
@@ -220,7 +220,14 @@ func (app *appContext) DeleteUser(user mediabrowser.User) (err error, deleted bo
 			}
 		}
 	}
-
+	
+	// Delete in Jellyseerr
+	if app.js != nil {
+		if err := app.js.DeleteUser(user.ID); err != nil {
+			app.err.Printf(lm.FailedDeleteUser, lm.Jellyseerr, user.ID, err)
+		}
+	}
+	
 	if app.discord != nil && app.config.Section("discord").Key("disable_enable_role").MustBool(false) {
 		cmUser, ok := app.storage.GetDiscordKey(user.ID)
 		if ok {


### PR DESCRIPTION
Currently, when a user is deleted in jfa-go, their Jellyseerr account is not removed. Ombi handles this already in `DeleteUser()` in `users.go` . This PR adds the same behavior for Jellyseerr.

`js.DeleteUser` takes the Jellyfin user ID directly, so no additional 
lookup is needed unlike the Ombi case.

I saw the `FIXME`, but I figured if there is already an interim solution for Ombi... Apologies for the tiny PR--selfishly just trying to avoid having to build from source.

Tested manually against Seerr 3.1.0 with manual deletion. 